### PR TITLE
Use `setbufline` instead of `nvim_buf_set_lines`

### DIFF
--- a/lua/format/formatter.lua
+++ b/lua/format/formatter.lua
@@ -71,7 +71,7 @@ function M.startTask(configs, startLine, endLine, force, write)
   function F.run(current)
     name = current.name
     local exe = current.config.exe
-    local args = table.concat(current.config.args, " ")
+    local args = table.concat(current.config.args or {}, " ")
     local cmd_str = string.format("%s %s", exe, args)
     local job_id =
       vim.fn.jobstart(

--- a/lua/format/util.lua
+++ b/lua/format/util.lua
@@ -2,16 +2,11 @@ local vim = vim
 local util = {}
 
 function util.log(...)
-  vim.api.nvim_out_write(table.concat(vim.tbl_flatten {...}) .. "\n")
-end
-
-function util.inspect(val)
-  print(vim.inspect(val))
+  vim.api.nvim_out_write("Formatter: " .. table.concat(vim.tbl_flatten {...}) .. "\n")
 end
 
 function util.error(...)
-  print(table.concat(...))
-  vim.api.nvim_error_write(table.concat(vim.tbl_flatten {...}) .. "\n")
+  vim.api.nvim_err_write(table.concat(vim.tbl_flatten {...}) .. "\n")
 end
 
 function util.setLines(bufnr, startLine, endLine, lines)
@@ -44,27 +39,8 @@ function util.split(s, sep, plain)
   end
 end
 
-function util.isSame(a, b)
-  if type(a) ~= type(b) then
-    return false
-  end
-  if type(a) == "table" then
-    if #a ~= #b then
-      return false
-    end
-    for k, v in pairs(a) do
-      if not util.isSame(b[k], v) then
-        return false
-      end
-    end
-    return true
-  else
-    return a == b
-  end
-end
-
 function util.fireEvent(event)
-  local cmd = string.format('silent doautocmd <nomodeline> User %s', event)
+  local cmd = string.format("silent doautocmd <nomodeline> User %s", event)
   vim.api.nvim_command(cmd)
 end
 return util


### PR DESCRIPTION
`nvim_buf_set_lines` blows away all jumps, marks and folds.
If we use `setbufline` to replace the lines one by one, we can have our
cake and eat it too.

Extra: don't even start formatting when the buffer is not modifiable.