### PR TITLE
Add fallback to o.args to prevent throwing an error

### DIFF
--- a/lua/format/formatter.lua
+++ b/lua/format/formatter.lua
@@ -51,7 +51,7 @@ function formatter.startTask(name, conf, startLine, endLine)
   local bufnr = api.nvim_get_current_buf()
   local lines = util.getLines(bufnr, startLine, endLine)
   local cmd = o.exe
-  local args = table.concat(o.args, " ")
+  local args = table.concat(o.args or {}, " ")
   local stdin = o.stdin or false
 
   if (stdin == true) then


### PR DESCRIPTION
Currently, if a user doesn't pass an `args` table, the plugin will throw an error
because `table.concat()` is trying to concat a table but it's receiving `nil` 

Some formatters work fine without any args & just passing an empty args table to
prevent the error IMO should be handled by the plugin.

Maybe another way to fix this is to change the `defaults` object in `config.lua` to
be `defaults or {args ={}}` but I didn't try that