### PR TITLE
Remove no formatters defined message

### DIFF
--- a/lua/format/formatter.lua
+++ b/lua/format/formatter.lua
@@ -30,7 +30,6 @@ function formatter.internalFormatter(userFmtTable, startLine, endLine)
   local formatters = config.values[filetype]
   -- No formatters defined for the given file type
   if (util.isEmpty(formatters)) then
-    print(string.format("Format: no formatter defined for %s files", filetype))
     return
   end
 


### PR DESCRIPTION
This is a bit of a preference than a fix, but I think the log doesn't make much
sense & removing it actually can simplify the setup a bit.

```vim
autocmd BufWritePre * Format
```

Instead of keeping track of which filetypes that should be formatted in two
places, the table inside setup & the `autocmd`.

The user can just add this `autocmd` & forget about it & the plugin will do the
right thing.