### PR TITLE
fix README example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ require('formatter').setup({
           stdin = true
         }
       end
-    }
+    },
     lua = {
         -- luafmt
         function()


### PR DESCRIPTION
Add a missing comma `,` to the example code to make it works.