### PR TITLE
add support for embedded syntax formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ require('formatter').setup({
           }
         end
       }
+  },
+  embedded = {
+    {
+      start_pattern = "^lua << EOF$",
+      end_pattern = "^EOF$",
+      filetype = "lua"
+    },
+    {
+      start_pattern = "^```javascript$",
+      end_pattern = "^```$",
+      filetype = "javascript"
+    }
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -74,5 +74,8 @@ This mean things will run in the order you list them, keep this in mind.
 Each formatter should return a table that consist of:
 - `exe`: the program you wish to run
 - `args`: a table of args to pass
-- `stdin`: If it should use stdin or not. As of now, only stdin tools are supported. But will add support for reading files.
+- `stdin`: If it should use stdin or not.
+- `tempfile_dir`:  directory for temp file when not using stdin (optional)
+- `tempfile_prefix`:  prefix for temp file when not using stdin (optional)
+- `tempfile_postfix`:  postfix for temp file when not using stdin (optional)
 

--- a/lua/formatter/embedded.lua
+++ b/lua/formatter/embedded.lua
@@ -1,0 +1,77 @@
+local util = require "formatter.util"
+local config = require "formatter.config"
+local format = require "formatter.format"
+
+local M = {}
+
+function M.format(args, startLine, endLine, write)
+  local userPassedFmt = util.split(args, " ")
+  local modifiable = vim.bo.modifiable
+  if not modifiable then
+    util.print("Buffer is not modifiable")
+    return
+  end
+
+  local F = {}
+  local configs = {}
+
+  function F.run(current)
+    M.startTask(current, startLine, endLine, write, F.step)
+  end
+
+  function F.step()
+    if #configs == 0 then
+      return
+    end
+    F.run(table.remove(configs, 1))
+  end
+
+  for _, embedded in pairs(config.values.embedded or {}) do
+    local formatters = config.values.filetype[embedded.filetype]
+    if not util.isEmpty(formatters) then
+      local configsToRun = util.getConfigsToRun(userPassedFmt, formatters)
+
+      table.insert(
+        configs,
+        {
+          start_pattern = embedded.start_pattern,
+          end_pattern = embedded.end_pattern,
+          configs = configsToRun
+        }
+      )
+    end
+  end
+
+  F.step()
+end
+
+function M.startTask(opts, firstLine, lastLine, write, cb)
+  local view = vim.fn.winsaveview()
+
+  vim.fn.cursor(firstLine, 1)
+  local startLine = vim.fn.search(opts.start_pattern, "Wc")
+  if startLine == 0 then
+    vim.fn.winrestview(view)
+    cb()
+    return
+  end
+  local endLine = vim.fn.search(opts.end_pattern, "W")
+  if endLine == 0 or endLine > lastLine then
+    vim.fn.winrestview(view)
+    cb()
+    return
+  end
+
+  startLine = startLine
+  endLine = endLine - 1
+
+  local callback = function()
+    M.startTask(opts, startLine + 1, lastLine, write, cb)
+  end
+
+  format.startTask(vim.deepcopy(opts.configs), startLine, endLine, write, callback)
+
+  vim.fn.winrestview(view)
+end
+
+return M

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -34,16 +34,21 @@ end
 function M.startTask(configs, startLine, endLine, write)
   local F = {}
   local bufnr = api.nvim_get_current_buf()
+  local bufname = vim.fn.bufname(bufnr)
   local input = util.getLines(bufnr, startLine, endLine)
   local output = input
   local errOutput = nil
   local name
   local currentOutput
+  local tempfiles = {}
 
-  function F.on_event(_, data, event)
+  function F.on_event(job_id, data, event)
     if event == "stdout" then
       if data[#data] == "" then
         data[#data] = nil
+      end
+      if tempfiles[job_id] ~= nil then
+        data = util.read_temp_file(tempfiles[job_id])
       end
       if not util.isEmpty(data) then
         currentOutput = data
@@ -60,11 +65,15 @@ function M.startTask(configs, startLine, endLine, write)
     end
 
     if event == "exit" then
+      if tempfiles[job_id] ~= nil then
+        os.remove(tempfiles[job_id])
+      end
+
       -- Data is exit code here
       -- Failed to run, stop the loop
       if data > 0 then
         if errOutput then
-          util.err(string.format('failed to run formatter %s', name))
+          util.err(string.format("failed to run formatter %s", name))
         end
       end
 
@@ -74,9 +83,7 @@ function M.startTask(configs, startLine, endLine, write)
         output = currentOutput
         F.step()
       end
-
     end
-
   end
 
   function F.run(current)
@@ -84,19 +91,36 @@ function M.startTask(configs, startLine, endLine, write)
     local exe = current.config.exe
     local args = table.concat(current.config.args or {}, " ")
     local cmd_str = string.format("%s %s", exe, args)
-    local job_id =
-      vim.fn.jobstart(
-      cmd_str,
-      {
-        on_stderr = F.on_event,
-        on_stdout = F.on_event,
-        on_exit = F.on_event,
-        stdout_buffered = true,
-        stderr_buffered = true
-      }
-    )
-    vim.fn.chansend(job_id, output)
-    vim.fn.chanclose(job_id, "stdin")
+    if current.config.stdin then
+      local job_id =
+        vim.fn.jobstart(
+        cmd_str,
+        {
+          on_stderr = F.on_event,
+          on_stdout = F.on_event,
+          on_exit = F.on_event,
+          stdout_buffered = true,
+          stderr_buffered = true
+        }
+      )
+      vim.fn.chansend(job_id, output)
+      vim.fn.chanclose(job_id, "stdin")
+    else
+      local tempfile_name = util.create_temp_file(bufname, output, current.config)
+      cmd_str = string.format("%s %s", cmd_str, tempfile_name)
+      local job_id =
+        vim.fn.jobstart(
+        cmd_str,
+        {
+          on_stderr = F.on_event,
+          on_stdout = F.on_event,
+          on_exit = F.on_event,
+          stdout_buffered = true,
+          stderr_buffered = true
+        }
+      )
+      tempfiles[job_id] = tempfile_name
+    end
   end
 
   -- Process through each config
@@ -112,7 +136,6 @@ function M.startTask(configs, startLine, endLine, write)
 
   function F.done()
     if not util.isSame(input, output) then
-
       local view = vim.fn.winsaveview()
       util.setLines(bufnr, startLine, endLine, output)
       vim.fn.winrestview(view)
@@ -120,7 +143,6 @@ function M.startTask(configs, startLine, endLine, write)
       if write and bufnr == api.nvim_get_current_buf() then
         vim.api.nvim_command("noautocmd :update")
       end
-
     else
       util.print(string.format("No change necessary with %s", name))
     end

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -21,17 +21,11 @@ function M.format(args, startLine, endLine, write)
     util.print(string.format("No formatter defined for %s files", filetype))
     return
   end
-  local configsToRun = {}
-  for _, val in ipairs(formatters) do
-    local tmp = val()
-    if userPassedFmt == nil or userPassedFmt[tmp.exe] then
-      table.insert(configsToRun, {config = tmp, name = tmp.exe})
-    end
-  end
+  local configsToRun = util.getConfigsToRun(userPassedFmt, formatters)
   M.startTask(configsToRun, startLine, endLine, write)
 end
 
-function M.startTask(configs, startLine, endLine, write)
+function M.startTask(configs, startLine, endLine, write, cb)
   local F = {}
   local bufnr = api.nvim_get_current_buf()
   local bufname = vim.fn.bufname(bufnr)
@@ -148,7 +142,9 @@ function M.startTask(configs, startLine, endLine, write)
     end
 
     util.fireEvent("FormatterPost")
-    return
+    if cb ~= nil then
+      cb()
+    end
   end
 
   -- AND start the loop

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -129,7 +129,7 @@ function M.startTask(configs, startLine, endLine, write, cb)
   end
 
   function F.done()
-    if not util.isSame(input, output) then
+    if not util.isEmpty(output) and not util.isSame(input, output) then
       local view = vim.fn.winsaveview()
       util.setLines(bufnr, startLine, endLine, output)
       vim.fn.winrestview(view)

--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -89,4 +89,41 @@ function util.fireEvent(event)
   vim.api.nvim_command(cmd)
 end
 
+function util.create_temp_file(bufname, input, opts)
+  local split_bufname = vim.split(bufname, "/")
+  local tempfile_prefix = opts.tempfile_prefix or "~formatting"
+  local tempfile_postfix = opts.tempfile_postfix or ""
+  local filename =
+    ("%s_%d_%s%s"):format(tempfile_prefix, math.random(1, 1000000), split_bufname[#split_bufname], tempfile_postfix)
+  split_bufname[#split_bufname] = nil
+  local tempfile_dir = table.concat(split_bufname, "/")
+  if tempfile_dir == "" then
+    tempfile_dir = "."
+  end
+  local tempfile_name = ("%s/%s"):format((opts.tempfile_dir or tempfile_dir), filename)
+
+  local tempfile = io.open(tempfile_name, "w+")
+  for _, line in pairs(input) do
+    tempfile:write(line .. "\n")
+  end
+  tempfile:flush()
+  tempfile:close()
+
+  return tempfile_name
+end
+
+function util.read_temp_file(tempfile_name)
+  local tempfile = io.open(tempfile_name, "r")
+  if tempfile == nil then
+    return
+  end
+  local lines = {}
+  for line in tempfile:lines() do
+    table.insert(lines, line)
+  end
+  tempfile:close()
+
+  return lines
+end
+
 return util

--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -126,4 +126,15 @@ function util.read_temp_file(tempfile_name)
   return lines
 end
 
+function util.getConfigsToRun(userPassedFmt, formatters)
+  local configsToRun = {}
+  for _, val in ipairs(formatters) do
+    local tmp = val()
+    if userPassedFmt == nil or userPassedFmt[tmp.exe] then
+      table.insert(configsToRun, {config = tmp, name = tmp.exe})
+    end
+  end
+  return configsToRun
+end
+
 return util

--- a/plugin/formatter.vim
+++ b/plugin/formatter.vim
@@ -9,3 +9,11 @@ command! -nargs=? -range=%
 command! -nargs=? -range=%
       \ -complete=customlist,s:formatter_complete
       \ FormatWrite lua require("formatter.format").format(<q-args>, <line1>, <line2>, true)
+
+command! -nargs=? -range=%
+      \ -complete=customlist,s:formatter_complete
+      \ FormatEmbedded lua require("formatter.embedded").format(<q-args>, <line1>, <line2>, false)
+
+command! -nargs=? -range=%
+      \ -complete=customlist,s:formatter_complete
+      \ FormatEmbeddedWrite lua require("formatter.embedded").format(<q-args>, <line1>, <line2>, true)


### PR DESCRIPTION
And here is embedded syntax formatting

you add a config block that maps start/end pattern to a filetype

```
embedded = {
    {
        start_pattern = "^lua << EOF$",
        end_pattern = "^EOF$",
        filetype = "lua"
    },
}
```

And commands `FormatEmbedded` and `FormatEmbeddedWrite`

This PR uses the other as the base, so look at that first.
I noticed my use of snake case and camel case isn't really consistent, I'll clean that up, but check first if there is anything else I should fix too.