### PR TITLE
Pass cmd as a string to jobstart

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -106,7 +106,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
     if current.config.stdin then
       local job_id =
         vim.fn.jobstart(
-        cmd,
+        table.concat(cmd, " "),
         {
           on_stderr = F.on_event,
           on_stdout = F.on_event,
@@ -122,7 +122,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
       table.insert(cmd, tempfile_name)
       local job_id =
         vim.fn.jobstart(
-        cmd,
+        table.concat(cmd, " "),
         {
           on_stderr = F.on_event,
           on_stdout = F.on_event,


### PR DESCRIPTION
After upgrading the plugin, `prettier` kept failing to run, I tracked down the changes & it seems that in the latest changes here https://github.com/mhartington/formatter.nvim/commit/6cc7d40b7fe0d82e4fe4cd1adc5553e0c9646969 it introduced a  change in the way the `cmd` was passed to `jobstart` from a string https://github.com/mhartington/formatter.nvim/blob/87e2de66779d0e857ba2993b20bbcd0cbc1bfc6d/lua/formatter/format.lua#L90-L94 to a table https://github.com/mhartington/formatter.nvim/blob/6cc7d40b7fe0d82e4fe4cd1adc5553e0c9646969/lua/formatter/format.lua#L109 https://github.com/mhartington/formatter.nvim/blob/6cc7d40b7fe0d82e4fe4cd1adc5553e0c9646969/lua/formatter/format.lua#L95-L100

This PR keeps the old behaviour of passing a string, which is according to the `:h jobstart()` is the right thing, also that was the only change that made prettier work again.

This was the minimal config I tried which was failing without this change.

```lua
javascript = {
  function()
    return {
      exe = "prettier",
      args = {
        "--stdin-filepath",
        vim.fn.shellescape(vim.api.nvim_buf_get_name(0))
      },
      stdin = true
    }
  end
}
```