### PR TITLE
Add option to make a command not run in a shell

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -106,7 +106,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
     if current.config.stdin then
       local job_id =
         vim.fn.jobstart(
-        table.concat(cmd, " "),
+        current.config.no_shell and cmd or table.concat(cmd, " "),
         {
           on_stderr = F.on_event,
           on_stdout = F.on_event,
@@ -122,7 +122,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
       table.insert(cmd, tempfile_name)
       local job_id =
         vim.fn.jobstart(
-        table.concat(cmd, " "),
+        current.config.no_shell and cmd or table.concat(cmd, " "),
         {
           on_stderr = F.on_event,
           on_stdout = F.on_event,


### PR DESCRIPTION
One of my formatters gets passed off to `sed`, which was broken by #38.
Additionally, running commands in a shell causes it to be affected by what `&shell` is set to.

I'll admit I don't entirely understand why #38 was needed, but this should retain the behaviour
that it added. It adds a `no_shell` option, which if set to `true`, passes the command as a table to `jobstart`.
If it's `false` (or `nil` since that's falsey) then the current behaviour is maintained.
