### PR TITLE
Fix: Index out of bounds

### DIFF
--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -36,7 +36,7 @@ function util.error(...)
 end
 
 function util.setLines(bufnr, startLine, endLine, lines)
-  return vim.api.nvim_buf_set_lines(bufnr, startLine, endLine, true, lines)
+  return vim.api.nvim_buf_set_lines(bufnr, startLine, endLine, false, lines)
 end
 
 function util.getLines(bufnr, startLine, endLine)


### PR DESCRIPTION
I ran into this error while formatting a markdown file:
Before:
```
$x$ 
$x + y$
```

After:
```
$x$ $x + y$
```

This would cause an index out of bounds error since the `util.setLines` function is trying to set lines which don't exist anymore i.e. the second line. 

In the documentation for `nvim_buf_set_lines` we can read:
```
nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing}, {replacement})

                ...

                Out-of-bounds indices are clamped to the nearest valid value,
                unless `strict_indexing` is set.
```

Which was indeed previously set to true and therefore caused errors.

Do note that I don't know enough of this function to confidently say setting `strict_indexing` to `false` doesn't cause any unforeseen side effects so I'd advice the maintainers to take a look at that.

For reproducing the error here's the config I used for the formatter:
```lua
local pandoc = function()
  local markdown_extensions = {
    'markdown',
    'tex_math_single_backslash',
    'raw_tex',
    'latex_macros',
    'definition_lists',
    'backtick_code_blocks',
    'fenced_code_attributes',
    'inline_code_attributes'
  }
  return {
    args = {
      'pandoc',
      '--to=markdown',
      '-sp',
      '--tab-stop=2',
      '--from=' .. table.concat(markdown_extensions, '+')
    },
    stdin = true
  }
end
```