### PR TITLE
Provide better error message when the user has configured the formatter incorrectly.

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -77,7 +77,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
       -- Failed to run, stop the loop
       if data > 0 then
         if errOutput then
-          util.err(string.format("failed to run formatter %s", name))
+          util.err(string.format("failed to run formatter %s", name .. ". " .. table.concat(errOutput)))
         end
       end
 

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -9,7 +9,6 @@ function M.format(args, startLine, endLine, write)
   local userPassedFmt = util.split(args, " ")
   local modifiable = vim.bo.modifiable
   local filetype = vim.bo.filetype
-  print('check filetype', filetype)
   local formatters = config.values.filetype[filetype]
 
   if not modifiable then

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -9,6 +9,7 @@ function M.format(args, startLine, endLine, write)
   local userPassedFmt = util.split(args, " ")
   local modifiable = vim.bo.modifiable
   local filetype = vim.bo.filetype
+  print('check filetype', filetype)
   local formatters = config.values.filetype[filetype]
 
   if not modifiable then
@@ -149,6 +150,11 @@ function M.startTask(configs, startLine, endLine, format_then_write)
   function F.done()
     if not util.isSame(input, output) then
       local view = vim.fn.winsaveview()
+      -- print('check values here', bufnr, startLine, endLine, output)
+		if not output then
+            util.err(string.format("Formatter: Formatted code not found. You may need to change the stdin setting of %s.", name))
+			return
+		end
       util.setLines(bufnr, startLine, endLine, output)
       vim.fn.winrestview(view)
 

--- a/lua/formatter/init.lua
+++ b/lua/formatter/init.lua
@@ -2,7 +2,7 @@ local config = require("formatter.config")
 
 local M = {}
 function M.setup(o)
-  config.set_defaults(o)
+	config.set_defaults(o)
 end
 
 return M


### PR DESCRIPTION
This has been an issue for myself before I finally figured out what does `stdin` mean in the config. Without this conditional check, `formatter.nvim` will throw error and the exception is not handled.