### PR TITLE
Provide a better default config with `tbl_extend`

### DIFF
--- a/lua/formatter/config.lua
+++ b/lua/formatter/config.lua
@@ -3,11 +3,10 @@ _FormatterConfigurationValues = _FormatterConfigurationValues or {}
 local config = {}
 config.values = _FormatterConfigurationValues
 
-function config.set_defaults(defaults)
-  defaults = defaults or {}
-  config.values = defaults
+function config.set_defaults(user_opts)
+  config.values = vim.tbl_extend('force', { filetype = {}}, user_opts)
 end
 
-config.set_defaults()
+config.set_defaults({})
 
 return config

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -77,7 +77,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
       -- Failed to run, stop the loop
       if data > 0 then
         if errOutput then
-          util.err(string.format("failed to run formatter %s", name))
+          util.err(string.format("failed to run formatter %s", name .. ". " .. table.concat(errOutput)))
         end
       end
 


### PR DESCRIPTION
Use `vim.tbl_extend` to avoid exception when `filetype` is not provided.