### PR TITLE
Add example config for ruby and note examples in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ nnoremap <silent> <leader>f :Format<CR>
 
 ## Configure
 
-By default there are no tools configured. This may change.
-
 To config a tool, you can create a table for the filetype and tool you want to use
 
 ```lua
@@ -109,3 +107,7 @@ augroup FormatAutogroup
 augroup END
 ]], true)
 ```
+
+## Example configurations
+
+By default there are no tools configured. This may change in the future. For now there are examples in side `example/` for reference.

--- a/example/ruby.lua
+++ b/example/ruby.lua
@@ -1,0 +1,16 @@
+-- Enable rubocop formatting in ruby
+require('formatter').setup({
+  logging = false,
+  filetype = {
+    ruby = {
+      -- rubocop run on one file
+      function()
+        return {
+          exe = "rubocop", -- might prepend `bundle exec `
+          args = { '--auto-correct', '--stdin', '%:p', '2>/dev/null', '|', 'sed "1,/^====================$/d"' },
+          stdin = true,
+        }
+      end
+    }
+  }
+})


### PR DESCRIPTION
This pull request suggests creating an example folder to contain configurations for multiple languages. It creates values for new users and gives them inspiration before they can customize the configurations on their own. Moreover, some languages are especially tricky to set up. The example that I include is Ruby, where from this https://github.com/rubocop/rubocop/issues/2502 we can learn that they output a delimiter after auto-correcting the file, which makes the output looks weird. These are glitches that Ale, EFM, and Neoformat have silently overcome: 
https://github.com/kimihito/dotfiles/commit/222a14370662334381bfc691701f08182405b3ab 
https://github.com/sbdchd/neoformat/pull/49 
https://github.com/dense-analysis/ale/issues/1695