### PR TITLE
Fix #67

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ require('formatter').setup({
        function()
           return {
             exe = "clang-format",
-            args = {},
+            args = {"--assume-filename", vim.api.nvim_buf_get_name(0)},
             stdin = true,
             cwd = vim.fn.expand('%:p:h')  -- Run clang-format in cwd of the file.
           }


### PR DESCRIPTION
Make running clang-format via formatter behave the same as running from command-line.