### PR TITLE
fix(job): continue the loop if formatter fails

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -67,7 +67,6 @@ function M.startTask(configs, startLine, endLine, format_then_write)
       end
       if not util.isEmpty(data) then
         errOutput = data
-        F.step()
       end
     end
 
@@ -87,8 +86,8 @@ function M.startTask(configs, startLine, endLine, format_then_write)
       if ignore_exitcode or data == 0 then
         util.print(string.format("Finished running %s", name))
         output = currentOutput
-        F.step()
       end
+      F.step()
     end
   end
 


### PR DESCRIPTION
If a job fails, we should still continue the loop.
Would appreciate a second set of eyes @lukas-reineke.



Closes #63