### PR TITLE
docs(): add black example

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -141,3 +141,21 @@ require('formatter').setup({
   }
 })
 ```
+## Black
+
+```lua
+require('formatter').setup({
+  filetype = {
+    python = {
+      -- Configuration for psf/black
+      function()
+        return {
+          exe = "black", -- this should be available on your $PATH
+          args = { '-' },
+          stdin = true,
+        }
+      end
+    }
+  }
+})
+```


### PR DESCRIPTION
Possibly closes #86.
This is the method I used to set up formatter.nvim for [black](https://github.com/psf/black).

That being said, this is awfully similar to the stylua configuration!
So if, for the sake of brevity, it is decided not to merge this in, I would completely understand.

Cheers!