### PR TITLE
feat(): remove "No changes necessary with {formatter}" print

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -178,8 +178,6 @@ function M.startTask(configs, startLine, endLine, format_then_write)
         vim.api.nvim_command("update")
         M.saving = false
       end
-    else
-      util.print(string.format("No change necessary with %s", name))
     end
 
     util.fireEvent("FormatterPost")


### PR DESCRIPTION
Hey @mhartington 👋 

Love the plugin but this one log when there are no changes seems to me to just get in the way. As a user I don't want the plugin to print for me unless it's useful information. And telling me essentially, 'you're already formatted' is not useful IMO.

This just removes that line.

The other option would be to put this print behind the `logging` option, but I couldn't quite figure out how to do that (not too familiar with neovim plugins)