### PR TITLE
docs: add config for terraform fmt

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -141,3 +141,21 @@ require('formatter').setup({
   }
 })
 ```
+
+## terraform
+
+```lua
+require('formatter').setup({
+  filetype = {
+    terraform = {
+      function()
+        return {
+          exe = "terraform",
+          args = { "fmt", "-" },
+          stdin = true
+        }
+      end
+    }
+  }
+})
+```


### PR DESCRIPTION
The "-" argument must be provided to the terraform fmt command in order to read from STDIN. From `terraform fmt -h`:

        If DIR is not specified then the current working directory will be used.
        If DIR is "-" then content will be read from STDIN. The given content must
        be in the Terraform language native syntax; JSON is not supported.