### PR TITLE
add some better logging logic

### DIFF
--- a/lua/formatter/config.lua
+++ b/lua/formatter/config.lua
@@ -5,7 +5,7 @@ config.values = _FormatterConfigurationValues
 
 function config.set_defaults(defaults)
   defaults = defaults or {}
-  config.values = vim.tbl_extend('force', { filetype = {}}, defaults)
+  config.values = vim.tbl_extend("force", {filetype = {}}, defaults)
 end
 
 config.set_defaults()

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -99,7 +99,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
 
   function F.run(current)
     if inital_changedtick ~= vim.api.nvim_buf_get_changedtick(bufnr) then
-      util.info("Buffer changed while formatting, skipping")
+      util.debug("Buffer changed while formatting, skipping")
       return
     end
 

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -24,7 +24,7 @@ function M.format(args, mods, startLine, endLine, write)
   local configsToRun = {}
   -- No formatters defined for the given file type
   if util.isEmpty(formatters) then
-    util.eror(string.format("No formatter defined for %s files", filetype))
+    util.error(string.format("No formatter defined for %s files", filetype))
     return
   end
   for _, val in ipairs(formatters) do
@@ -84,7 +84,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
       -- Failed to run, stop the loop
       if not ignore_exitcode and data > 0 then
         if errOutput then
-          util.eror(string.format("failed to run formatter %s", name .. ". " .. table.concat(errOutput)))
+          util.error(string.format("failed to run formatter %s", name .. ". " .. table.concat(errOutput)))
         end
       end
 

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -15,23 +15,25 @@ function M.format(args, mods, startLine, endLine, write)
   local filetype = vim.bo.filetype
   local formatters = config.values.filetype[filetype]
 
+
   if not modifiable then
-    util.print("Buffer is not modifiable")
+    util.info("Buffer is not modifiable")
     return
   end
 
+  local configsToRun = {}
   -- No formatters defined for the given file type
   if util.isEmpty(formatters) then
-    util.err(string.format("No formatter defined for %s files", filetype))
+    util.eror(string.format("No formatter defined for %s files", filetype))
     return
   end
-  local configsToRun = {}
   for _, val in ipairs(formatters) do
     local tmp = val()
     if userPassedFmt == nil or userPassedFmt[tmp.exe] then
       table.insert(configsToRun, {config = tmp, name = tmp.exe})
     end
   end
+
   M.startTask(configsToRun, startLine, endLine, write)
 end
 
@@ -49,7 +51,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
   local buf_skip_format = util.getBufVar(bufnr, "formatter_skip_buf") or false
   local tempfiles = {}
   if buf_skip_format then
-    util.print("Formatting turn off for buffer")
+    util.info("Formatting turn off for buffer")
     return
   end
   function F.on_event(job_id, data, event)
@@ -82,13 +84,13 @@ function M.startTask(configs, startLine, endLine, format_then_write)
       -- Failed to run, stop the loop
       if not ignore_exitcode and data > 0 then
         if errOutput then
-          util.err(string.format("failed to run formatter %s", name .. ". " .. table.concat(errOutput)))
+          util.eror(string.format("failed to run formatter %s", name .. ". " .. table.concat(errOutput)))
         end
       end
 
       -- Success
       if ignore_exitcode or data == 0 then
-        util.log(string.format("Finished running %s", name))
+        util.info(string.format("Finished running %s", name))
         output = currentOutput
       end
       F.step()
@@ -97,7 +99,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
 
   function F.run(current)
     if inital_changedtick ~= vim.api.nvim_buf_get_changedtick(bufnr) then
-      util.print("Buffer changed while formatting, skipping")
+      util.info("Buffer changed while formatting, skipping")
       return
     end
 
@@ -164,7 +166,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
     if not util.isSame(input, output) then
       local view = vim.fn.winsaveview()
       if not output then
-        util.err(
+        util.error(
           string.format("Formatter: Formatted code not found. You may need to change the stdin setting of %s.", name)
         )
         return
@@ -178,7 +180,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
         M.saving = false
       end
     else
-      util.log(string.format("No change necessary with %s", name))
+      util.info(string.format("No change necessary with %s", name))
     end
 
     util.fireEvent("FormatterPost")

--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -1,10 +1,44 @@
 local config = require("formatter.config")
 local loggingEnabled = config.values.logging
-
+local log_level = config.values.log_level
 local util = {}
 util.mods = nil
 
 local notify_opts = {title = 'Formatter'}
+
+
+-- vim.log = {
+--   levels = {
+--     TRACE = 0;
+--     DEBUG = 1;
+--     INFO  = 2;
+--     WARN  = 3;
+--     ERROR = 4;
+--   }
+-- }
+
+
+function util.debug(txt)
+  if log_level == vim.log.levels.DEBUG then
+    vim.notify(txt, vim.log.levels.DEBUG, notify_opts)
+  end
+end
+function util.info(txt)
+  if log_level == vim.log.levels.INFO then
+    vim.notify(txt, vim.log.levels.INFO, notify_opts)
+  end
+end
+function util.warn(txt)
+  if log_level == vim.log.levels.WARN then
+    vim.notify(txt, vim.log.levels.WARN, notify_opts)
+  end
+end
+function util.error(...)
+  if log_level == vim.log.levels.WARN then
+    vim.notify(table.concat(vim.tbl_flatten {...}), vim.log.levels.WARN, notify_opts)
+  end
+end
+
 
 local pathSeparator = (function()
   local jit = require("jit")
@@ -28,14 +62,6 @@ function util.print(msg)
   end
 end
 
--- Always print error message to cmd line
-function util.err(msg)
-  if util.mods ~= 'silent' then
-    local txt = string.format("Formatter: %s", msg)
-    vim.notify(txt, vim.log.levels.ERROR, notify_opts)
-  end
-end
-
 -- Generic logging
 function util.log(...)
   if loggingEnabled then
@@ -49,12 +75,6 @@ function util.inspect(val)
   end
 end
 
-function util.error(...)
-  if loggingEnabled then
-    print(table.concat(...))
-    vim.api.nvim_error_write(table.concat(vim.tbl_flatten {...}) .. "\n")
-  end
-end
 
 function util.setLines(bufnr, startLine, endLine, lines)
   return vim.api.nvim_buf_set_lines(bufnr, startLine, endLine, false, lines)


### PR DESCRIPTION
This adds some better logging logic. 

Making use of neovim's own internal log levels, we can only print to the log area if the users asks for it.

```lua
vim.log = {
  levels = {
    TRACE = 0;
    DEBUG = 1;
    INFO  = 2;
    WARN  = 3;
    ERROR = 4;
  }
}
```

Based on these default values, we can ask users to enable logging if they want it.

```
formatter.setup(
  {
    logging = true,
    log_level = 2,
    filetype = formatterConfig
  }
)
```

This will make the `logging` option no long needed. 

If they do not want any logging, they can simply leave out the `log_level` from their setup function, and they will not have any.

If they need to debug issues, they can set the appropriate level in the setup function.


This will allow the plugin to set appropriate logs internally and not worry about annoying users. 