### PR TITLE
Add config for latexindent

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -199,3 +199,21 @@ require("formatter").setup({
   }
 })
 ```
+
+## latexindent
+
+```lua
+require("formatter").setup({
+	filetype = {
+		tex = {
+			function()
+				return {
+					exe = "latexindent",
+					args = { "-" },
+					stdin = true,
+				}
+			end,
+		},
+	},
+})
+```


### PR DESCRIPTION
A config for the latexindent perl script that ships with texlive, works on linux, should work on mac. I think it should work on windows too as latexindent ships as an exe with miktex but I've not tested. See https://github.com/cmhughes/latexindent.pl for details.