### PR TITLE
Add Synchronous versions of the Format commands

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -131,7 +131,7 @@ function M.startTask(configs, startLine, endLine, opts)
         cwd = current.config.cwd or vim.fn.getcwd(),
     }
 
-	local job_id = nil
+    local job_id = nil
 
     if current.config.stdin then
       job_id =
@@ -152,7 +152,7 @@ function M.startTask(configs, startLine, endLine, opts)
       tempfiles[job_id] = tempfile_name
     end
 
-    if sync then
+    if opts.sync then
       vim.fn.jobwait({job_id})
     end
   end
@@ -185,7 +185,7 @@ function M.startTask(configs, startLine, endLine, opts)
       util.setLines(bufnr, startLine, endLine, output)
       vim.fn.winrestview(view)
 
-      if format_then_write and bufnr == api.nvim_get_current_buf() then
+      if opts.write and bufnr == api.nvim_get_current_buf() then
         M.saving = true
         vim.api.nvim_command("update")
         M.saving = false

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -4,7 +4,7 @@ local util = require "formatter.util"
 
 local M = {}
 
-function M.format(args, mods, startLine, endLine, write, sync)
+function M.format(args, mods, startLine, endLine, opts)
   if M.saving then
     return
   end
@@ -34,10 +34,14 @@ function M.format(args, mods, startLine, endLine, write, sync)
     end
   end
 
-  M.startTask(configsToRun, startLine, endLine, write, sync)
+  M.startTask(configsToRun, startLine, endLine, opts)
 end
 
-function M.startTask(configs, startLine, endLine, format_then_write, sync)
+function M.startTask(configs, startLine, endLine, opts)
+  opts = opts or {}
+  local format_then_write = opts.write or false
+  local sync = opts.sync or false
+
   local F = {}
   local bufnr = api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(bufnr)

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -38,9 +38,10 @@ function M.format(args, mods, startLine, endLine, opts)
 end
 
 function M.startTask(configs, startLine, endLine, opts)
-  opts = opts or {}
-  local format_then_write = opts.write or false
-  local sync = opts.sync or false
+  opts = vim.tbl_deep_extend("keep", opts or {}, {
+    write = false,
+    sync = false,
+  })
 
   local F = {}
   local bufnr = api.nvim_get_current_buf()

--- a/plugin/formatter.vim
+++ b/plugin/formatter.vim
@@ -4,8 +4,16 @@ endfunction
 
 command! -nargs=? -range=% -bar
       \ -complete=customlist,s:formatter_complete
-      \ Format lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, false)
+      \ Format lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, false, false)
 
 command! -nargs=? -range=% -bar
       \ -complete=customlist,s:formatter_complete
-      \ FormatWrite lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, true)
+      \ FormatWrite lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, true, false)
+
+command! -nargs=? -range=% -bar
+      \ -complete=customlist,s:formatter_complete
+      \ FormatSync lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, false, true)
+
+command! -nargs=? -range=% -bar
+      \ -complete=customlist,s:formatter_complete
+      \ FormatWriteSync lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, true, true)

--- a/plugin/formatter.vim
+++ b/plugin/formatter.vim
@@ -4,16 +4,16 @@ endfunction
 
 command! -nargs=? -range=% -bar
       \ -complete=customlist,s:formatter_complete
-      \ Format lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, false, false)
+      \ Format lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>)
 
 command! -nargs=? -range=% -bar
       \ -complete=customlist,s:formatter_complete
-      \ FormatWrite lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, true, false)
+      \ FormatWrite lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, {write = true})
 
 command! -nargs=? -range=% -bar
       \ -complete=customlist,s:formatter_complete
-      \ FormatSync lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, false, true)
+      \ FormatSync lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, {sync = true})
 
 command! -nargs=? -range=% -bar
       \ -complete=customlist,s:formatter_complete
-      \ FormatWriteSync lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, true, true)
+	  \ FormatWriteSync lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, {write = true, sync = true})


### PR DESCRIPTION
Implements #108 

Adds synchronous versions of the existing `Format` commands.

I've also added a commit which changes the format function to accept a table of options instead of a series of boolean. This should make it easier to extend in the future but I'm happy to revert it if it's not wanted!