### PR TITLE
Add `--edition` arg to `rustfmt`

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -33,7 +33,7 @@ require('formatter').setup({
       function()
         return {
           exe = "rustfmt",
-          args = {"--emit=stdout"},
+          args = {"--emit=stdout", "--edition=2021"},
           stdin = true
         }
       end


### PR DESCRIPTION
`rustfmt` defaults to 2015 edition which doesn't not know anything about eg `async fn` syntax. The formatter then fails silently without any clue in `:messages`, so it took me some time, digging into the formatter source, before running `rustfmt` by hands and getting the error. Pinning the last edition obviously isn't perfect, as people work on legacy projects, but I believe removing the arg much easier than finding one to add :)

Would it worth adding into `:messages` something like: "an error occurred while calling `rustfmt --emit=stdout main.rs`, run the command by hands to see the error details"?