### PR TITLE
Converts optional parameters to a table

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -4,7 +4,7 @@ local util = require "formatter.util"
 
 local M = {}
 
-function M.format(args, mods, startLine, endLine, write)
+function M.format(args, mods, startLine, endLine, opts)
   if M.saving then
     return
   end
@@ -34,10 +34,15 @@ function M.format(args, mods, startLine, endLine, write)
     end
   end
 
-  M.startTask(configsToRun, startLine, endLine, write)
+  M.startTask(configsToRun, startLine, endLine, opts)
 end
 
-function M.startTask(configs, startLine, endLine, format_then_write)
+function M.startTask(configs, startLine, endLine, opts)
+  opts = vim.tbl_deep_extend("keep", opts or {}, {
+    write = false,
+  })
+
+
   local F = {}
   local bufnr = api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(bufnr)
@@ -174,7 +179,7 @@ function M.startTask(configs, startLine, endLine, format_then_write)
       util.setLines(bufnr, startLine, endLine, output)
       vim.fn.winrestview(view)
 
-      if format_then_write and bufnr == api.nvim_get_current_buf() then
+      if opts.write and bufnr == api.nvim_get_current_buf() then
         M.saving = true
         vim.api.nvim_command("update")
         M.saving = false

--- a/plugin/formatter.vim
+++ b/plugin/formatter.vim
@@ -4,8 +4,8 @@ endfunction
 
 command! -nargs=? -range=% -bar
       \ -complete=customlist,s:formatter_complete
-      \ Format lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, false)
+      \ Format lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>)
 
 command! -nargs=? -range=% -bar
       \ -complete=customlist,s:formatter_complete
-      \ FormatWrite lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, true)
+      \ FormatWrite lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, {write=true})


### PR DESCRIPTION
Separate PR created from #109 for converting `write` to an opts table to make it easy to extend in the future.