### PR TITLE
Added HCL formatter

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -180,6 +180,8 @@ require('formatter').setup({
 
 ## HCL (Hashicop Configuration Language)
 
+Reference: https://terragrunt.gruntwork.io/docs/getting-started/configuration/#formatting-hcl-files
+
 ```lua
 -- plugin-config
 require('formatter').setup({

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -178,6 +178,37 @@ require('formatter').setup({
 })
 ```
 
+## HCL (Hashicop Configuration Language)
+
+```lua
+-- plugin-config
+require('formatter').setup({
+  filetype = {
+    hcl = {
+      function()
+        return {
+          exec = "terragrunt",
+          args = {"hclfmt"},
+          stdin = false
+        }
+      end
+    },
+  }
+})
+
+-- autocmd-config
+vim.api.nvim_exec(
+  [[
+    augroup FormatAutogroup
+      autocmd!
+      autocmd BufWritePost *.hcl,*.tf FormatWrite
+      autocmd BufNewFile,BufRead *.hcl set filetype=terraform syntax=terraform
+    augroup END
+  ]],
+  true
+)
+```
+
 ## Black
 
 ```lua


### PR DESCRIPTION
## summary

Introduced HCL Formatter for `*.hcl` filetype.

## References

- https://github.com/gruntwork-io/terragrunt/issues/1037#issuecomment-583057827
- https://terragrunt.gruntwork.io/docs/getting-started/configuration/#formatting-hcl-files