### PR TITLE
Implement sync formatting with buffer locking

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -39,6 +39,7 @@ end
 
 function M.startTask(configs, startLine, endLine, opts)
   opts = vim.tbl_deep_extend("keep", opts or {}, {
+    sync = false,
     write = false,
   })
 
@@ -108,6 +109,10 @@ function M.startTask(configs, startLine, endLine, opts)
       return
     end
 
+    if opts.sync then
+      vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+    end
+
     name = current.name
     ignore_exitcode = current.config.ignore_exitcode
     local cmd = {current.config.exe}
@@ -166,6 +171,10 @@ function M.startTask(configs, startLine, endLine, opts)
     if inital_changedtick ~= vim.api.nvim_buf_get_changedtick(bufnr) then
       util.print("Buffer changed while formatting, not applying formatting")
       return
+    end
+
+    if opts.sync then
+      vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
     end
 
     if not util.isSame(input, output) then

--- a/plugin/formatter.vim
+++ b/plugin/formatter.vim
@@ -8,4 +8,12 @@ command! -nargs=? -range=% -bar
 
 command! -nargs=? -range=% -bar
       \ -complete=customlist,s:formatter_complete
-      \ FormatWrite lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, {write=true})
+      \ FormatWrite lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, { write = true })
+
+command! -nargs=? -range=% -bar
+      \ -complete=customlist,s:formatter_complete
+	  \ FormatSync lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, { sync = true })
+
+command! -nargs=? -range=% -bar
+      \ -complete=customlist,s:formatter_complete
+      \ FormatWriteSync lua require("formatter.format").format(<q-args>, <q-mods>, <line1>, <line2>, { sync = true, write = true })


### PR DESCRIPTION
Following on from #109, this PR adds sync formatting commands by making the buffer unmodifiable until formatting is complete.