### PR TITLE
Feature/transform

### DIFF
--- a/lua/formatter/filetypes/ruby.lua
+++ b/lua/formatter/filetypes/ruby.lua
@@ -1,0 +1,24 @@
+local M = {}
+
+local util = require("formatter.util")
+
+function M.rubocop()
+	return {
+		exe = "rubocop",
+		args = {
+			"--fix-layout",
+			"--stdin",
+			util.escape_path(util.get_current_buffer_file_name()),
+			"--format",
+			"files",
+		},
+		stdin = true,
+		transform = function(text)
+			table.remove(text, 1)
+			table.remove(text, 1)
+			return text
+		end,
+	}
+end
+
+return M

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -59,7 +59,7 @@ function M.startTask(configs, startLine, endLine, opts)
     util.info("Formatting turn off for buffer")
     return
   end
-  function F.on_event(job_id, data, event)
+  function F.on_event(transform, job_id, data, event)
     if event == "stdout" then
       if data[#data] == "" then
         data[#data] = nil
@@ -96,7 +96,7 @@ function M.startTask(configs, startLine, endLine, opts)
       -- Success
       if ignore_exitcode or data == 0 then
         util.info(string.format("Finished running %s", name))
-        output = currentOutput
+        output = transform and transform(currentOutput) or currentOutput
       end
       F.step()
     end
@@ -122,10 +122,13 @@ function M.startTask(configs, startLine, endLine, opts)
       return
     end
 
+    local on_event = function(...)
+      F.on_event(current.config.transform, ...)
+    end
     local job_options = {
-        on_stderr = F.on_event,
-        on_stdout = F.on_event,
-        on_exit = F.on_event,
+        on_stderr = on_event,
+        on_stdout = on_event,
+        on_exit = on_event,
         stdout_buffered = true,
         stderr_buffered = true,
         cwd = current.config.cwd or vim.fn.getcwd(),


### PR DESCRIPTION
adds a transform parameter that transforms the output of a formatter before using it to format files

rationale is that `rubocop` (a ruby formatter) adds an uneeded header in the output and you have to remove that in the final output to format the file so i added a `transform` parameter which takes the output of the formatter and transforms it into whatever we need

related to #137 so i suggest merging that first