### PR TITLE
fix(): handle formatter with metatable

### DIFF
--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -86,6 +86,10 @@ end
 
 function util.isEmpty(s)
   if type(s) == "table" then
+    local mt = getmetatable(s)
+    if mt and mt.__call then
+      return false
+    end
     for _, v in pairs(s) do
       if not util.isEmpty(v) then
         return false


### PR DESCRIPTION
With this fix, a table with a `__call` metatable event can be used in
place of a formatter config function.