### PR TITLE
Pre/post hook log_level integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ a reference to create our own opt-in default formatter configurations.
 - Asynchronous execution
 - Opt-in default formatter configurations
 - Conditional formatting
+- Before/after format hooks
 
 ## Install
 
@@ -145,6 +146,20 @@ augroup FormatAutogroup
   autocmd BufWritePost * FormatWrite
 augroup END
 ```
+
+### Before/after format hooks
+
+You can execute code before and after formatting like so:
+```vim
+augroup FormatAutogroup
+  autocmd!
+  autocmd User FormatterPre lua print "This will print before formatting"
+  autocmd User FormatterPost lua print "This will print after formatting"
+augroup END
+```
+
+Note that these commands are executed using `silent` when the `log_level`
+is higher than `vim.log.levels.DEBUG`.
 
 ### Configuration specification
 

--- a/doc/formatter.txt
+++ b/doc/formatter.txt
@@ -29,6 +29,7 @@ CONTENTS
  - Written in `lua`
  - Asynchronous execution
  - Opt-in default formatter configurations
+ - Before/after format hooks
 
 
 ==============================================================================
@@ -164,6 +165,22 @@ Format and write after save asynchronously:
     autocmd BufWritePost * FormatWrite
   augroup END
 <
+
+                                                               *formatter-hooks*
+Before/after format hooks
+
+You can execute code before and after formatting like so:
+>
+  augroup FormatAutogroup
+    autocmd!
+    autocmd User FormatterPre lua print "This will print before formatting"
+    autocmd User FormatterPost lua print "This will print after formatting"
+  augroup END
+<
+
+Note that these commands are executed using `silent` when the `log_level`
+is higher than `vim.log.levels.DEBUG`.
+
 
 ------------------------------------------------------------------------------
                                                          *formatter-config-spec*

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -199,12 +199,16 @@ function M.start_task(configs, start_line, end_line, opts)
       log.info(string.format("No change necessary with %s", name))
     end
 
-    util.fire_event "FormatterPost"
+    util.fire_event(
+      "FormatterPost",
+      config.values.log_level > vim.log.levels.DEBUG
+    )
   end
 
-  -- AND start the loop
-
-  util.fire_event "FormatterPre"
+  util.fire_event(
+    "FormatterPre",
+    config.values.log_level > vim.log.levels.DEBUG
+  )
   F.step()
 end
 

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -199,16 +199,12 @@ function M.start_task(configs, start_line, end_line, opts)
       log.info(string.format("No change necessary with %s", name))
     end
 
-    util.fire_event(
-      "FormatterPost",
-      config.values.log_level > vim.log.levels.DEBUG
-    )
+    local silent = config.values.log_level > vim.log.levels.DEBUG
+    util.fire_event("FormatterPost", silent)
   end
 
-  util.fire_event(
-    "FormatterPre",
-    config.values.log_level > vim.log.levels.DEBUG
-  )
+  local silent = config.values.log_level > vim.log.levels.DEBUG
+  util.fire_event("FormatterPre", silent)
   F.step()
 end
 

--- a/lua/formatter/log.lua
+++ b/lua/formatter/log.lua
@@ -16,6 +16,8 @@ function M.trace(txt)
     and config.values.log_level <= vim.log.levels.TRACE
     and not M.is_current_format_silent()
   then
+    -- NOTE: lsp thinks vim.notify takes one argument
+    ---@diagnostic disable-next-line
     vim.notify(txt, vim.log.levels.TRACE, M.notify_opts)
   end
 end
@@ -26,6 +28,8 @@ function M.debug(txt)
     and config.values.log_level <= vim.log.levels.DEBUG
     and not M.is_current_format_silent()
   then
+    -- NOTE: lsp thinks vim.notify takes one argument
+    ---@diagnostic disable-next-line
     vim.notify(txt, vim.log.levels.DEBUG, M.notify_opts)
   end
 end
@@ -36,6 +40,8 @@ function M.info(txt)
     and config.values.log_level <= vim.log.levels.INFO
     and not M.is_current_format_silent()
   then
+    -- NOTE: lsp thinks vim.notify takes one argument
+    ---@diagnostic disable-next-line
     vim.notify(txt, vim.log.levels.INFO, M.notify_opts)
   end
 end
@@ -46,6 +52,8 @@ function M.warn(txt)
     and config.values.log_level <= vim.log.levels.WARN
     and not M.is_current_format_silent()
   then
+    -- NOTE: lsp thinks vim.notify takes one argument
+    ---@diagnostic disable-next-line
     vim.notify(txt, vim.log.levels.WARN, M.notify_opts)
   end
 end
@@ -56,6 +64,8 @@ function M.error(txt)
     and config.values.log_level <= vim.log.levels.ERROR
     and not M.is_current_format_silent()
   then
+    -- NOTE: lsp thinks vim.notify takes one argument
+    ---@diagnostic disable-next-line
     vim.notify(txt, vim.log.levels.ERROR, M.notify_opts)
   end
 end

--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -121,8 +121,12 @@ function M.get_lines(bufnr, startLine, endLine)
   return vim.api.nvim_buf_get_lines(bufnr, startLine, endLine, true)
 end
 
-function M.fire_event(event)
-  local cmd = string.format("silent doautocmd <nomodeline> User %s", event)
+function M.fire_event(event, silent)
+  local cmd = string.format(
+    "%s doautocmd <nomodeline> User %s",
+    silent and "silent" or "",
+    event
+  )
   vim.api.nvim_command(cmd)
 end
 


### PR DESCRIPTION
Use `silent` on pre/post format hooks only when `log_level` is higher than `vim.log.levels.DEBUG`.

fixes #143 