### PR TITLE
fix(json.jq): fix jq config

### DIFF
--- a/lua/formatter/filetypes/json.lua
+++ b/lua/formatter/filetypes/json.lua
@@ -16,7 +16,8 @@ M.denofmt = util.copyf(defaults.denofmt)
 function M.jq()
   return {
     exe = "jq",
-    args = ".",
+    args = { "." },
+    stdin = true,
   }
 end
 


### PR DESCRIPTION
# Description

Fix the `jq` config.

- The args property should be a list; and
- `jq` should read from stdin.
