### PR TITLE
Add sh filetype with shfmt formatter.

### DIFF
--- a/lua/formatter/filetypes/sh.lua
+++ b/lua/formatter/filetypes/sh.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+function M.shfmt()
+  local shiftwidth = vim.opt.shiftwidth._value
+  local expandtab = vim.opt.expandtab._value
+
+  if not expandtab then
+    shiftwidth = 0
+  end
+
+  return {
+    exe = "shfmt",
+    args = { "-i", shiftwidth },
+    stdin = true,
+  }
+end
+
+return M

--- a/lua/formatter/filetypes/sh.lua
+++ b/lua/formatter/filetypes/sh.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 function M.shfmt()
-  local shiftwidth = vim.opt.shiftwidth._value
-  local expandtab = vim.opt.expandtab._value
+  local shiftwidth = vim.opt.shiftwidth:get()
+  local expandtab = vim.opt.expandtab:get()
 
   if not expandtab then
     shiftwidth = 0


### PR DESCRIPTION
It was inspired by [neoformat formatter for sh](https://github.com/sbdchd/neoformat/blob/master/autoload/neoformat/formatters/sh.vim)
To test it you need to install ``shfmt``, then create any sh or bash file.
E.g. I tested this on my own local script, copy-paste this.

```sh
#!/usr/bin/env bash

# Extract archives - use: extract <file>

help() {
echo "Usage: extract [file]

Available file formats:
  .tar
  .tar.bz2
  .tar.gz
  .tbz2
  .tgz
  .bz2
  .rar
  .gz
  .zip
  .Z
  .7z"
}

if [ -f "$1" ] ; then
  case "$1" in
    *.tar) tar xvf "$1" ;;
    *.tar.bz2) tar xvjf "$1" ;;
    *.tar.gz) tar xvzf "$1" ;;
    *.tbz2) tar xvjf "$1" ;;
    *.tgz) tar xvzf "$1" ;;
    *.bz2) bunzip2 "$1" ;;
    *.rar) rar x "$1" ;;
    *.gz) gunzip "$1" ;;
    *.zip) unzip "$1" ;;
    *.Z) uncompress "$1" ;;
    *.7z) 7z x "$1" ;;
    *) echo "'$1' cannot be extracted via extract()" && help ;;
  esac
else
    help
fi
``` 