### PR TITLE
remove '\n` at the end of lines

### DIFF
--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -114,7 +114,14 @@ end
 -- Vim
 
 function M.set_lines(bufnr, startLine, endLine, lines)
-  return vim.api.nvim_buf_set_lines(bufnr, startLine, endLine, false, lines)
+  new_lines = {}
+  for _, val in ipairs(lines) do
+    if #val > 0 and vim.opt.fileformat:get() == "dos" then
+      table.insert(new_lines, string.sub(val, 0, #val - 1))
+    end
+  end
+
+  return vim.api.nvim_buf_set_lines(bufnr, startLine, endLine, false, new_lines)
 end
 
 function M.get_lines(bufnr, startLine, endLine)


### PR DESCRIPTION
When fileformat is 'dos' and using clang-format, formatter will add a '\n` at every lines

