### PR TITLE
Add eelixir formatting using prettier

### DIFF
--- a/lua/formatter/filetypes/eelixir.lua
+++ b/lua/formatter/filetypes/eelixir.lua
@@ -1,0 +1,9 @@
+local M = {}
+
+local defaults = require "formatter.defaults"
+local util = require "formatter.util"
+
+M.prettier = util.withl(defaults.prettier, "html")
+
+return M
+

--- a/lua/formatter/filetypes/eelixir.lua
+++ b/lua/formatter/filetypes/eelixir.lua
@@ -6,4 +6,3 @@ local util = require "formatter.util"
 M.prettier = util.withl(defaults.prettier, "html")
 
 return M
-


### PR DESCRIPTION
eelixir is the filetype for eex files. These are commonly used for
templating using html with Elixir. Using prettier with an eex plugin
can format this.

https://github.com/adamzapasnik/prettier-plugin-eex

Since it's a generic templating language, html might not be completely accurate though. Because it requires piping in the parser (in my testing) this is a simpler solution than manually applying it. 