### PR TITLE
solve rustfmt edition problem

### DIFF
--- a/lua/formatter/filetypes/rust.lua
+++ b/lua/formatter/filetypes/rust.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.rustfmt()
   return {
-    exe = "rustfmt",
+    exe = "rustfmt --edition 2021",
     stdin = true,
   }
 end


### PR DESCRIPTION
set the edition option of default rustfmt config to 2021.
the previous config only supports rust 2015 so it doesn't format files containing new features like `async fn xxx`
just pass the edition option to rustfmt is fine.