### PR TITLE
fix: Preserve logging config if specified.

### DIFF
--- a/lua/formatter/config.lua
+++ b/lua/formatter/config.lua
@@ -63,7 +63,9 @@ function M.normalize_config(valid_config)
   end
   normalized = vim.tbl_deep_extend("force", normalized, valid_config)
 
-  normalized.logging = normalized.logging or M.default_config.logging
+  if normalized.logging == nil then
+    normalized.logging = M.default_config.logging
+  end
   normalized.log_level = normalized.log_level or M.default_config.log_level
   normalized.filetype = normalized.filetype or M.default_config.filetype
 


### PR DESCRIPTION
The `logging` configuration option was always
replaced by the default value when set to `false`.

I have to say though that I'm not even sure why this line
was needed, since the defaults are already copied from the
`default_config` when instantiating the `normalized` config.