### PR TITLE
fix: stdin arg in cmake-format

### DIFF
--- a/lua/formatter/filetypes/cmake.lua
+++ b/lua/formatter/filetypes/cmake.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.cmakeformat()
   return {
     exe = "cmake-format",
-    arg = { "-" },
+    args = { "-" },
     stdin = true,
   }
 end

--- a/lua/formatter/filetypes/cmake.lua
+++ b/lua/formatter/filetypes/cmake.lua
@@ -3,6 +3,7 @@ local M = {}
 function M.cmakeformat()
   return {
     exe = "cmake-format",
+    arg = { "-" },
     stdin = true,
   }
 end


### PR DESCRIPTION
cmake-format read from stdin by add `-` before inputfile
fix: #168 
reference: https://github.com/cheshirekow/cmake_format/issues/30#issuecomment-380167572