### PR TITLE
Add haskell filetype with stylish-haskell

### DIFF
--- a/lua/formatter/filetypes/haskell.lua
+++ b/lua/formatter/filetypes/haskell.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+function M.stylish_haskell()
+  return {
+    exe = "stylish-haskell",
+    stdin = true,
+  }
+end
+
+return M


### PR DESCRIPTION
Unfortunately, stylish-haskell doesn't have a flag like `--stdin-filepath` for passing path to the file passed to stdin, so it doesn't look for a config relative to a saved file.