### PR TITLE
Add php support

### DIFF
--- a/lua/formatter/defaults/phpcbf.lua
+++ b/lua/formatter/defaults/phpcbf.lua
@@ -1,0 +1,7 @@
+return function()
+  return {
+    exe = "phpcbf",
+    stdin = true,
+    ignore_exitcode = true,
+  }
+end

--- a/lua/formatter/filetypes/php.lua
+++ b/lua/formatter/filetypes/php.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+local defaults = require "formatter.defaults"
+local util = require "formatter.util"
+
+M.phpcbf = util.copyf(defaults.phpcbf)
+
+return M


### PR DESCRIPTION
`phpcbf` returns a non-zero code by default, so the option `ignore_exitcode` is also set to `true` by default.