### PR TITLE
Add latex support (with latexindent)

### DIFF
--- a/lua/formatter/defaults/latexindent.lua
+++ b/lua/formatter/defaults/latexindent.lua
@@ -1,8 +1,10 @@
-return {
-  exe = "latexindent",
-  args = {
-    "-g",
-    "/dev/null"
-  },
-  stdin = true,
-}
+return function()
+  return {
+    exe = "latexindent",
+    args = {
+      "-g",
+      "/dev/null",
+    },
+    stdin = true,
+  }
+end

--- a/lua/formatter/defaults/latexindent.lua
+++ b/lua/formatter/defaults/latexindent.lua
@@ -1,0 +1,8 @@
+return {
+  exe = "latexindent",
+  args = {
+    "-g",
+    "/dev/null"
+  },
+  stdin = true,
+}

--- a/lua/formatter/filetypes/latex.lua
+++ b/lua/formatter/filetypes/latex.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+function M.latexindent()
+  return {
+    exe = "latexindent",
+    args = {
+      "-g",
+      "/dev/null",
+    },
+    stdin = true,
+  }
+end
+
+return M

--- a/lua/formatter/filetypes/latex.lua
+++ b/lua/formatter/filetypes/latex.lua
@@ -1,14 +1,8 @@
 local M = {}
 
-function M.latexindent()
-  return {
-    exe = "latexindent",
-    args = {
-      "-g",
-      "/dev/null",
-    },
-    stdin = true,
-  }
-end
+local util = require "formatter.util"
+local defaults = require "formatter.defaults"
+
+M.latexindent = util.copyf(defaults.latexindent)
 
 return M


### PR DESCRIPTION
Created `latexindent.lua` in `defaults/` for the formatter and `latex.lua` in `filetypes/` that uses the default formatter.