### PR TITLE
fix: If method is already called do not call it again

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -28,8 +28,13 @@ function M.format(args, mods, start_line, end_line, opts)
     log.info(string.format("No formatter defined for %s files", filetype))
     return
   end
-  for _, formatter_config_function in ipairs(formatters) do
-    local formatter = formatter_config_function()
+  for _, formatter_config in ipairs(formatters) do
+    local formatter
+    if type(formatter_config) == "table" then
+      formatter = formatter_config
+    else
+      formatter = formatter_config()
+    end
     if
       formatter
       and formatter.exe


### PR DESCRIPTION
After merging #207 I've tried to use it with the following config

`
require("formatter.filetypes.dart").dartformat({
	line_length = 120
}),
`

But it has failed because with passing parameters we have started to have the final table instead of having a function to call. I've added a check if the config is a table use it instead of calling it. I couldn't understand why we are calling these functions every time before format, instead of running and storing all of them at the set-up