### PR TITLE
Use sed as a pipe (the default behaviour)

### DIFF
--- a/lua/formatter/defaults/sed.lua
+++ b/lua/formatter/defaults/sed.lua
@@ -4,9 +4,8 @@ return function(pattern, replacement, flags)
   return {
     exe = "sed",
     args = {
-      "--in-place",
       util.quote_cmd_arg(util.wrap_sed_replace(pattern, replacement, flags)),
     },
-    stdin = false,
+    stdin = true,
   }
 end


### PR DESCRIPTION
In-place mode varies between GNU and BSD (incl. macOS) sed: GNU accepts e.g. -i.bak or -i; BSD wants -i .bak or -i ''. It's therefore difficult to invoke this in a cross-platform way as far as I know; you'd need to detect which one is being used or require that GNU sed is installed.

However, since the default behaviour of sed is to read from stdin and write to stdout, and formatter.nvim supports this behaviour quite straightforwardly, we can just do that instead.

Fixes #201 