### PR TITLE
Use `--stderr` flag for rubocop rather than parsing output

### DIFF
--- a/lua/formatter/filetypes/ruby.lua
+++ b/lua/formatter/filetypes/ruby.lua
@@ -11,13 +11,9 @@ function M.rubocop()
       util.escape_path(util.get_current_buffer_file_name()),
       "--format",
       "files",
+      "--stderr",
     },
     stdin = true,
-    transform = function(text)
-      table.remove(text, 1)
-      table.remove(text, 1)
-      return text
-    end,
   }
 end
 


### PR DESCRIPTION
I found that the rubocop formatter was always deleting the first line of the
file; it seems that this is because there might be a varying amount of output
before the line of `=====`.

Using the `--stderr` flag means that the linter warnings are effectively thrown away and so don't have to be trimmed out with a transform function.

I think this might fix #153 too.