### PR TITLE
Add --ast-check option for Zig

### DIFF
--- a/lua/formatter/defaults/zigfmt_astcheck.lua
+++ b/lua/formatter/defaults/zigfmt_astcheck.lua
@@ -1,0 +1,7 @@
+return function()
+  return {
+    exe = "zig",
+    args = { "fmt", "--ast-check", "--stdin" },
+    stdin = true,
+  }
+end

--- a/lua/formatter/filetypes/zig.lua
+++ b/lua/formatter/filetypes/zig.lua
@@ -4,5 +4,6 @@ local defaults = require "formatter.defaults"
 local util = require "formatter.util"
 
 M.zigfmt = util.copyf(defaults.zigfmt)
+M.zigfmt_astcheck = util.copyf(defaults.zigfmt_astcheck)
 
 return M


### PR DESCRIPTION
`zig fmt` comes with an option to simultaneously check the AST for basic mistakes like not using a variable. This is what I use in my config and it's really nice. I have added a preset for this.