### PR TITLE
Add current buffer's indent to clang-format, as a default instead of 2

### DIFF
--- a/lua/formatter/defaults/clangformat.lua
+++ b/lua/formatter/defaults/clangformat.lua
@@ -4,6 +4,7 @@ return function()
   return {
     exe = "clang-format",
     args = {
+      '-style="{IndentWidth: ' .. vim.api.nvim_buf_get_option(0, "tabstop") .. '}"',
       "-assume-filename",
       util.escape_path(util.get_current_buffer_file_name()),
     },


### PR DESCRIPTION
Couldn't find an util for the indent size...