### PR TITLE
save/restore views for all windows associated to buffer-being-formatted

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -195,7 +195,7 @@ function M.start_task(configs, start_line, end_line, opts)
     end
 
     if not util.is_same(input, output) then
-      local view = vim.fn.winsaveview()
+      local window_to_view = util.get_views_for_this_buffer()
       if not output then
         log.error(
           string.format(
@@ -207,7 +207,7 @@ function M.start_task(configs, start_line, end_line, opts)
         return
       end
       util.set_lines(bufnr, start_line, end_line, output)
-      vim.fn.winrestview(view)
+      util.restore_view_per_window(window_to_view)
 
       if opts.write and bufnr == vim.api.nvim_get_current_buf() then
         M.saving_currently = true

--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -156,7 +156,9 @@ end
 ---@see vim.fn.winrestview()
 function M.restore_view_per_window(window_to_view)
   for w, view in pairs(window_to_view) do
-    vim.api.nvim_win_call(w, function() vim.fn.winrestview(view) end)
+    if vim.api.nvim_win_is_valid(w) then
+      vim.api.nvim_win_call(w, function() vim.fn.winrestview(view) end)
+    end
   end
 end
 

--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -138,4 +138,26 @@ function M.get_buffer_variable(buf, var)
   return nil
 end
 
+--- get a table that maps a window to a view
+---@see vim.fn.winsaveview()
+function M.get_views_for_this_buffer()
+  local windows_containing_this_buffer = vim.fn.win_findbuf(vim.fn.bufnr())
+  local window_to_view = {}
+  for _, w in ipairs(windows_containing_this_buffer) do
+    vim.api.nvim_win_call(w, function()
+      window_to_view[w] = vim.fn.winsaveview()
+    end)
+  end
+  return window_to_view
+end
+
+--- restore view for each window
+---@param window_to_view table maps window to a view
+---@see vim.fn.winrestview()
+function M.restore_view_per_window(window_to_view)
+  for w, view in pairs(window_to_view) do
+    vim.api.nvim_win_call(w, function() vim.fn.winrestview(view) end)
+  end
+end
+
 return M


### PR DESCRIPTION
when having a split for a single buffer, if you do `FormatWrite`, the _other_ window will change its view (I would see it scroll to the top).

this PR solves this problem by handling _all_ windows views associated to current buffer, instead of just current window