### PR TITLE
Add --edition 2021 argument by default for rustfmt

### DIFF
--- a/lua/formatter/filetypes/rust.lua
+++ b/lua/formatter/filetypes/rust.lua
@@ -3,6 +3,7 @@ local M = {}
 function M.rustfmt()
   return {
     exe = "rustfmt",
+    args = { "--edition 2021" },
     stdin = true,
   }
 end


### PR DESCRIPTION
This enables the user to use the async fn keyword with rustfmt.
Related Issue: #220 