### PR TITLE
Fix dead link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Each formatter configuration should return a table that consist of:
   code (optional)
 - `transform` : pass a function that takes in the formatted text and returns
   the text to be applied to the buffer (optional) (see
-  [`ruby` `rubocop`](lua/formatter/filetypes/ruby) default formatter
+  [`ruby` `rubocop`](https://github.com/mhartington/formatter.nvim/blob/af59d125957b49577acdc927c013436f209c9843/lua/formatter/filetypes/ruby.lua#L16) default formatter
   configuration as an example)
 - `tempfile_dir`: directory for temp file when not using `stdin` (optional)
 - `tempfile_prefix`: prefix for temp file when not using `stdin` (optional)


### PR DESCRIPTION
While the `transform` attribute _has_ been in use in the rubocop formatter, it no longer is. We can link to a stable url to ensure it still serves as an example.