### PR TITLE
revert clang-format style arg

### DIFF
--- a/lua/formatter/defaults/clangformat.lua
+++ b/lua/formatter/defaults/clangformat.lua
@@ -4,7 +4,6 @@ return function()
   return {
     exe = "clang-format",
     args = {
-      '-style="{IndentWidth: ' .. vim.api.nvim_buf_get_option(0, "tabstop") .. '}"',
       "-assume-filename",
       util.escape_path(util.get_current_buffer_file_name()),
     },


### PR DESCRIPTION
This reverts https://github.com/mhartington/formatter.nvim/pull/222.

Clang-format by default sets the style to `file`, where it will use a user-provided configuration file if it exists. This is expected default behavior. The above PR overwrites this default.

This change is consistent with the defaults provided in other vim formatters like `sbdchd/neoformat`:
https://github.com/sbdchd/neoformat/blob/891fad5829f91cbc3d0866f7abd028d233b8763e/autoload/neoformat/formatters/c.vim#L16