### PR TITLE
Add support for ktlint (Kotlin)

### DIFF
--- a/lua/formatter/defaults/ktlint.lua
+++ b/lua/formatter/defaults/ktlint.lua
@@ -1,0 +1,13 @@
+local util = require "formatter.util"
+
+return function()
+    return {
+        exe = "ktlint",
+        args = {
+            "--stdin",
+            "--format",
+            "--log-level=none"
+        },
+        stdin = true
+    }
+end

--- a/lua/formatter/filetypes/kotlin.lua
+++ b/lua/formatter/filetypes/kotlin.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+function M.ktlint()
+    return {
+        exe = "ktlint",
+        args = {
+            "--stdin",
+            "--format",
+            "--log-level=none"
+        },
+        stdin = true
+    }
+end
+
+return M


### PR DESCRIPTION
Adding support for Kotlin through using [`ktlint`](https://github.com/pinterest/ktlint). I based the default formatter off of `clangformat.lua` and the filetype formatter off of `java.lua`. Let me know if there are any corrections that need to be made.
