### PR TITLE
Add current filename to mix format to enable picking up application config

### DIFF
--- a/lua/formatter/defaults/mixformat.lua
+++ b/lua/formatter/defaults/mixformat.lua
@@ -1,9 +1,13 @@
+local util = require "formatter.util"
+
 return function()
   return {
     exe = "mix",
     args = {
       "format",
       "-",
+      "--stdin-filename",
+      util.escape_path(util.get_current_buffer_file_path()),
     },
     stdin = true,
   }


### PR DESCRIPTION
A lot of Elixir libraries implement functionality with macros which extend the base language's syntax.

I noticed that by default, the `mixformat` formatter was ignoring formatting configuration that comes from dependency/sub-dir specific code.

Looks like `mix format` doesn't know what formatting to apply unless you supply a filepath.

This PR implements :point_up: 