### PR TITLE
add support for .erb files using erb-formatter

### DIFF
--- a/lua/formatter/filetypes/eruby.lua
+++ b/lua/formatter/filetypes/eruby.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+local util = require "formatter.util"
+
+function M.erbformatter()
+  return {
+    exe = "erb-formatter",
+    args = { util.escape_path(util.get_current_buffer_file_path()) },
+    stdin = true,
+  }
+end
+
+return M


### PR DESCRIPTION
This adds support for [.erb files](https://github.com/ruby/erb) being formatted using [erb-formatter](https://github.com/nebulab/erb-formatter).