### PR TITLE
Fix ocamlformat for ocaml files

### DIFF
--- a/lua/formatter/defaults/ocamlformat.lua
+++ b/lua/formatter/defaults/ocamlformat.lua
@@ -4,7 +4,7 @@ return function()
     exe = "ocamlformat",
     args = {
       "--enable-outside-detected-project",
-      util.escape_path(util.get_current_buffer_file_name()),
+      util.escape_path(util.get_current_buffer_file_path()),
     },
     stdin = true,
   }


### PR DESCRIPTION
Fixes ocaml so that formatter can format files inside source code directory irrespective of where the file is in the project

Already existing code only formats if the file is in the same directory as the workspace