### PR TITLE
fix: Do no append trailing underscore if tempfile_postfix is not set

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -160,6 +160,8 @@ function M.start_task(configs, start_line, end_line, opts)
     else
       -- TODO: handle null tempfile
       local tempfile_name = tempfile.create(bufname, output, current.config)
+      log.debug(string.format("Formatting temporary file at %s", tempfile_name))
+
       if not current.config.no_append then
         table.insert(cmd, util.escape_path(tempfile_name))
       end

--- a/lua/formatter/tempfile.lua
+++ b/lua/formatter/tempfile.lua
@@ -19,12 +19,21 @@ function M.create(buffer_path, content, options)
   local buffer_dir = vim.fn.fnamemodify(buffer_path, ":h")
   local buffer_name = vim.fn.fnamemodify(buffer_path, ":t")
 
-  local filename = ("%s_%d_%s_%s"):format(
-    options.tempfile_prefix or "~formatter",
-    math.random(1, 1000000),
-    buffer_name,
-    options.tempfile_postfix or ""
-  )
+  local filename
+  if type(options.tempfile_postfix) == "string" then
+    filename = ("%s_%d_%s_%s"):format(
+      options.tempfile_prefix or "~formatter",
+      math.random(1, 1000000),
+      buffer_name,
+      options.tempfile_postfix
+    )
+  else
+    filename = ("%s_%d_%s"):format(
+      options.tempfile_prefix or "~formatter",
+      math.random(1, 1000000),
+      buffer_name
+    )
+  end
 
   local path = (options.tempfile_dir or buffer_dir)
     .. M.path_separator


### PR DESCRIPTION
Some formatters (`treefmt`) _really_ want to know the file extension of any given file. Simply setting `tempfile_postfix` to an empty string is not enough to achieve this, because the format string will always append a `_`.

This PR does change the default behaviour, because without manually setting `tempfile_postfix` to at least an empty string, the trailing underscore will not be added anymore.