### PR TITLE
feat: add support for buf format

### DIFF
--- a/lua/formatter/filetypes/proto.lua
+++ b/lua/formatter/filetypes/proto.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+function M.buf_format()
+  return {
+    exe = "buf format",
+    args = {
+      '-w',
+    },
+    stdin = false,
+  }
+end
+
+return M


### PR DESCRIPTION
Added support for formatting proto files with `buf format`. Went with a filetype config directly instead of a default config, but happy to move it to a default if you think it makes sense.