### PR TITLE
Provide buf formatter

### DIFF
--- a/lua/formatter/filetypes/proto
+++ b/lua/formatter/filetypes/proto
@@ -1,0 +1,11 @@
+local M = {}
+
+function M.buf()
+  return { 
+    exe = "buf",
+    args = { "format" },
+    stdin = true,
+  }
+end
+
+return M


### PR DESCRIPTION
This is a formatter for protobuf-files. You can check it out here: https://github.com/bufbuild/buf

I am already using this in [my local config](https://github.com/jan-xyz/Dotfiles/blob/ffa093c92eed2e4128a8def4f0410980eddd1189/nvim/lua/plugins/formatter.lua#L7), and I thought I contribute it upstream.

There is also #268 which is writing the file directly, while this one is using stdin. I am not sure which one is the better approach.