### PR TITLE
feat: add default configuration for sqlfluff

### DIFF
--- a/lua/formatter/filetypes/sql.lua
+++ b/lua/formatter/filetypes/sql.lua
@@ -11,8 +11,7 @@ function M.sqlfluff()
   return {
     exe = "sqlfluff",
     args = {
-      "fix",
-      "--force",
+      "format",
       "--disable-progress-bar",
       "--nocolor",
       "-",

--- a/lua/formatter/filetypes/sql.lua
+++ b/lua/formatter/filetypes/sql.lua
@@ -7,4 +7,19 @@ function M.pgformat()
   }
 end
 
+function M.sqlfluff()
+  return {
+    exe = "sqlfluff",
+    args = {
+      "fix",
+      "--force",
+      "--disable-progress-bar",
+      "--nocolor",
+      "-",
+    },
+    stdin = true,
+    ignore_exitcode = true,
+  }
+end
+
 return M


### PR DESCRIPTION
Introduce a default configuration for `sqlfluff` inspired by [lua/null-ls/builtins/formatting/sqlfluff.lua](https://github.com/Carlosiano/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/sqlfluff.lua).