### PR TITLE
If the output is null, do not write

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -155,7 +155,11 @@ function M.start_task(configs, start_line, end_line, opts)
 
     if current.config.stdin then
       local job_id = vim.fn.jobstart(table.concat(cmd, " "), job_options)
-      vim.fn.chansend(job_id, output)
+
+      if next(output) ~= nil then
+        vim.fn.chansend(job_id, output)
+      end
+
       vim.fn.chanclose(job_id, "stdin")
     else
       -- TODO: handle null tempfile


### PR DESCRIPTION
If you save it as an empty file, `v:null` is write


![formatter_blank](https://github.com/mhartington/formatter.nvim/assets/12395688/af1e7f04-ea9b-468d-baa0-5fc48c715f5a)