### PR TITLE
Implement try_node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Each formatter configuration should return a table that consist of:
 - `stdin`: if it should use the standard input (optional)
 - `cwd` : the path to run the program from (optional)
 - `try_node_modules`: tries to run a formatter from locally install npm
-  packages (optional) (to be implemented)
+  packages (optional)
 - `no_append` : don't append the path of the file to the formatter command
   (optional)
 - `ignore_exitcode` : set to true if the program expects non-zero success exit
@@ -205,9 +205,9 @@ formatted causes, for example, `clang-format` to search for the nearest
 
 #### `try_node_modules`
 
-The `try_node_modules` argument is not yet implemented, but feel free to use
-this argument in your configurations. When we add support for it, you get
-the `node_modules` package scanning functionality automatically!
+The `try_node_modules` argument causes formatter.nvim to look for the formatter
+in `node_modules/.bin` before $PATH. `node_modules` path will be resolved only
+once per buffer and saved to `b:formatter_node_modules`.
 
 #### `no_append`
 

--- a/doc/formatter.txt
+++ b/doc/formatter.txt
@@ -208,7 +208,7 @@ Each formatter configuration should return a table that consist of:
 - `stdin`: if it should use the standard input (optional)
 - `cwd` : the path to run the program from (optional)
 - `try_node_modules`: tries to run a formatter from locally install npm
-  packages (optional) (to be implemented)
+  packages (optional)
 - `no_append` : don't append the path of the file to the formatter command
   (optional)
 - `ignore_exitcode` : set to true if the program expects non-zero success exit
@@ -229,11 +229,11 @@ formatted causes, for example, `clang-format` to search for the nearest
 `.clang-format` file in the file's parent directories.
 
 
-                                                    *formatter-try-node-modules*
+                           *formatter-try-node-modules* *b:formatter_node_modules*
 
-The `try_node_modules` argument is not yet implemented, but feel free to use
-this argument in your configurations. When we add support for it, you get
-the `node_modules` package scanning functionality automatically!
+The `try_node_modules` argument causes formatter.nvim to look for the formatter
+in `node_modules/.bin` before $PATH. `node_modules` path will be resolved only
+once per buffer and saved to |b:formatter_node_modules|.
 
 
                                                            *formatter-no-append*

--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -181,4 +181,32 @@ function M.restore_view_per_window(window_to_view)
     end
 end
 
+--- Find the closest node_modules path
+function M.find_node_modules(dir)
+  for p in vim.fs.parents(vim.fs.normalize(dir) .. "/") do
+    local node_modules = p .. "/node_modules"
+    if vim.fn.isdirectory(node_modules) == 1 then
+      return node_modules
+    end
+  end
+end
+
+function M.get_node_modules_bin_path(node_modules)
+  if not node_modules then
+    return nil
+  end
+
+  local bin_path = node_modules .. "/.bin"
+  if vim.fn.isdirectory(bin_path) ~= 1 then
+    return nil
+  end
+  return bin_path
+end
+
+if vim.fn.has("win32") == 1 then
+  M.path_separator = ";"
+else
+  M.path_separator = ":"
+end
+
 return M


### PR DESCRIPTION
This implementation prepends `$PATH` with `node_modules/.bin` when running `try_node_modules` formatters. To avoid `node_modules` lookups on every format, the path to `node_modules` (or lack of thereof) will be stored in `b:formatter_node_modules`.