### PR TITLE
Feat: Add ruff default configuration

### DIFF
--- a/lua/formatter/filetypes/python.lua
+++ b/lua/formatter/filetypes/python.lua
@@ -39,6 +39,14 @@ function M.black()
   }
 end
 
+function M.ruff()
+  return {
+    exe = "ruff",
+    args = { "--fix", "-" },
+    stdin = true,
+  }
+end
+
 function M.pyment()
   return {
     exe = "pyment",

--- a/lua/formatter/filetypes/python.lua
+++ b/lua/formatter/filetypes/python.lua
@@ -42,7 +42,7 @@ end
 function M.ruff()
   return {
     exe = "ruff",
-    args = { "--fix", "-" },
+    args = { "--fix", "-e", "-n", "--stdin-filename", "$FILENAME", "-" },
     stdin = true,
   }
 end


### PR DESCRIPTION
Project docs: https://docs.astral.sh/ruff/


### How to test
Add ruff to your formatter like so

```lua
require("formatter").setup({
    filetype = {
        python = {
            return require("formatter.filetypes.python").ruff()
        }
    }
})
```
Open a python project and have a pyproject.toml file ready like [so](https://docs.astral.sh/ruff/configuration/).
Open a python file and hit save or trigger the formatter directly.
