### PR TITLE
Add formatter for liquidsoap script.

### DIFF
--- a/lua/formatter/filetypes/liquidsoap.lua
+++ b/lua/formatter/filetypes/liquidsoap.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+function M.liquidsoap_prettier()
+  return {
+    exe = "liquidsoap-prettier",
+    args = {"--write"},
+    stdin = false
+  }
+end
+
+return M


### PR DESCRIPTION
Liquidsoap is scripting language for creating media streams and more. It's got about [1.8k](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.liq) (still counting!) script files on github.

We're in the process of adding much needed tooling for script developers with [tree sitter grammar](https://github.com/savonet/tree-sitter-liquidsoap) (supported in [nvim-tree-sitter](https://github.com/nvim-treesitter/nvim-treesitter/pull/5433)), [vscode/textmate syntax](https://github.com/savonet/vscode-liquidsoap) (hopefully to be used by [github-linguist](https://github.com/github-linguist/linguist/pull/6565) at some point!).

File type for vim was [added recently](https://github.com/vim/vim/commit/6b5efcdd8e976d2ab2554b22c4220c5e88de4717) and [backported to neovim](https://github.com/neovim/neovim/pull/25221)

This PR adds support for formatting liquidsoap code using (https://www.npmjs.com/package/liquidsoap-prettier).

Thanks for your consideration!