### PR TITLE
Add vim native trailing whitespace removal

### DIFF
--- a/lua/formatter/filetypes/any.lua
+++ b/lua/formatter/filetypes/any.lua
@@ -5,4 +5,8 @@ local util = require "formatter.util"
 
 M.remove_trailing_whitespace = util.withl(defaults.sed, "[ \t]*$")
 
+M.substitute_trailing_whitespace = function()
+    vim.cmd([[silent! :keeppatterns %s/\[ \t]+$//ge]])
+end
+
 return M


### PR DESCRIPTION
Hello! I ran across this when using Neovim in an environment where I didn't have sed, and thought that there was probably some simple implementation that didn't need to rely on any external binaries. I know sed is super common, but I figured this might be a useful add for anyone looking for this specific functionality. I took close care to make sure that this would not affect search history and would behave as similarly as possible to the sed implementation.

Open to different function naming, and happy to make any changes needed.

Thanks for considering!