### PR TITLE
Add support for `ruff format` in python.lua

### DIFF
--- a/lua/formatter/filetypes/python.lua
+++ b/lua/formatter/filetypes/python.lua
@@ -39,6 +39,14 @@ function M.black()
   }
 end
 
+function M.ruff()
+  return {
+    exe = "ruff format",
+    args = { "-q", "-" },
+    stdin = true,
+  }
+end
+
 function M.pyment()
   return {
     exe = "pyment",

--- a/lua/formatter/filetypes/python.lua
+++ b/lua/formatter/filetypes/python.lua
@@ -41,8 +41,8 @@ end
 
 function M.ruff()
   return {
-    exe = "ruff format",
-    args = { "-q", "-" },
+    exe = "ruff",
+    args = { "format", "-q", "-" },
     stdin = true,
   }
 end


### PR DESCRIPTION
Adding support for ruff's formatting module. It's 99.9% black compliant and runs orders of magnitude faster.