### PR TITLE
add sqlfluff formatter for postgres

### DIFF
--- a/lua/formatter/filetypes/sql.lua
+++ b/lua/formatter/filetypes/sql.lua
@@ -7,4 +7,20 @@ function M.pgformat()
   }
 end
 
+function M.sqlfluff_postgres()
+  return {
+    exe = "sqlfluff",
+    args = {
+      "fix",
+      "--disable-progress-bar",
+      "-f",
+      "-n",
+      "-",
+      "--dialect",
+      "postgres",
+    },
+    stdin = true,
+  }
+end
+
 return M


### PR DESCRIPTION
Here I'm contributing some of the local formatters I have configured, which could be interesting for anyone else. 

Ceveat here, not sure how to handle this, `sqlfluff` needs the `--dialect` argument for formatting sql. 
So either we would need to document how to adapt this, or keep it like it is right now. 