### PR TITLE
Improve default formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ require("formatter").setup {
       -- "formatter.filetypes.any" defines default configurations for any
       -- filetype
       require("formatter.filetypes.any").remove_trailing_whitespace,
+
+      -- Remove trailing whitespace without 'sed'
       -- require("formatter.filetypes.any").substitute_trailing_whitespace,
     }
   }

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ require("formatter").setup {
     ["*"] = {
       -- "formatter.filetypes.any" defines default configurations for any
       -- filetype
-      require("formatter.filetypes.any").remove_trailing_whitespace
+      require("formatter.filetypes.any").remove_trailing_whitespace,
+      -- require("formatter.filetypes.any").substitute_trailing_whitespace,
     }
   }
 }

--- a/doc/formatter.txt
+++ b/doc/formatter.txt
@@ -118,6 +118,8 @@ Setup:
         -- "formatter.filetypes.any" defines default configurations for any
         -- filetype
         require("formatter.filetypes.any").remove_trailing_whitespace,
+
+        -- Remove trailing whitespace without 'sed'
         -- require("formatter.filetypes.any").substitute_trailing_whitespace,
       }
     }

--- a/doc/formatter.txt
+++ b/doc/formatter.txt
@@ -117,7 +117,8 @@ Setup:
       ["*"] = {
         -- "formatter.filetypes.any" defines default configurations for any
         -- filetype
-        require("formatter.filetypes.any").remove_trailing_whitespace
+        require("formatter.filetypes.any").remove_trailing_whitespace,
+        -- require("formatter.filetypes.any").substitute_trailing_whitespace,
       }
     }
   }

--- a/lua/formatter/filetypes/any.lua
+++ b/lua/formatter/filetypes/any.lua
@@ -6,7 +6,16 @@ local util = require "formatter.util"
 M.remove_trailing_whitespace = util.withl(defaults.sed, "[ \t]*$")
 
 M.substitute_trailing_whitespace = function()
-    vim.cmd([[silent! :keeppatterns %s/\[ \t]+$//ge]])
+    local line, col = unpack(vim.api.nvim_win_get_cursor(0))
+
+    vim.cmd([[silent! :keeppatterns %s/[ \t]\+$//ge]])
+
+    -- Restore cursor position without going out of bounds
+    local lastline = vim.fn.line("$")
+    if line > lastline then
+        line = lastline
+    end
+    vim.api.nvim_win_set_cursor(0, { line, col })
 end
 
 return M


### PR DESCRIPTION
Improvement of my previous PR #297 

Fixed inconsistent escaping with search pattern causing unreliability
Maintain cursor position when substituting without updating jumplist
Add mention to docs for visibility ;) + trailing comma