### PR TITLE
feat: don't overwrite previous config

### DIFF
--- a/lua/formatter/init.lua
+++ b/lua/formatter/init.lua
@@ -9,7 +9,11 @@ function M.setup(user_config)
     return
   end
 
-  config.values = config.normalize_config(user_config)
+  config.values = vim.tbl_deep_extend(
+    "force",
+    config.values,
+    config.normalize_config(user_config)
+  )
 end
 
 return M


### PR DESCRIPTION
This allows to call setup multiple times e.g. to add formatters separately
I need this for a plugin of mine (https://github.com/max397574/typst-tools.nvim) where I want to add a new formatter

@mhartington would be really nice if this could get merged soon because this currently is completely blocking work on my new plugin
