### PR TITLE
fix: Update `sql.lua`

### DIFF
--- a/lua/formatter/filetypes/sql.lua
+++ b/lua/formatter/filetypes/sql.lua
@@ -17,7 +17,7 @@ function M.sqlfluff()
       "-",
     },
     stdin = true,
-    ignore_exitcode = true,
+    ignore_exitcode = false,
   }
 end
 


### PR DESCRIPTION
- Do not ignore errors, if `.sqlfluff` config file for example is not existing it will, result in an empty file.