### PR TITLE
Fix elixir/heex formatter

### DIFF
--- a/lua/formatter/defaults/mixformat.lua
+++ b/lua/formatter/defaults/mixformat.lua
@@ -1,8 +1,12 @@
+local util = require "formatter.util"
+
 return function()
   return {
     exe = "mix",
     args = {
       "format",
+      "--stdin-filename",
+      util.escape_path(util.get_current_buffer_file_path()),
       "-",
     },
     stdin = true,


### PR DESCRIPTION
mix formatter need `--stdin-filename`  for heex files. see https://github.com/elixir-lang/elixir/pull/11822

Fixes https://github.com/mhartington/formatter.nvim/issues/206