### PR TITLE
FormatAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ With [`dein.vim`](https://github.com/Shougo/dein.vim):
 call dein#add('mhartington/formatter.nvim')
 ```
 
+## Commands
+
+```vim
+[range]FormatAs {filetype}
+```
+
+Formats the range (defaulting to the whole file) as `{filetype}`, useful if you
+want to format code of `{filetype}` when embedded in a file of another
+filetype, for e.g. format a javascript snippet when inside markdown, or SQL
+inside of javascript, etc.
+
 ## Configure
 
 Setup:

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -49,6 +49,30 @@ function M.format(args, mods, start_line, end_line, opts)
   M.start_task(configs_to_run, start_line, end_line, opts)
 end
 
+function M.format_as(args, mods, start_line, end_line, opts)
+  local filetype = args
+  local formatters = config.formatters_for_filetype(filetype)
+
+  if util.is_empty(formatters) then
+    log.info(string.format("No formatter defined for %s files", filetype))
+    return
+  end
+
+  local configs = vim.tbl_map(function(config)
+    if type(config) == "table" then
+      return config
+    else
+      return config()
+    end
+  end, formatters)
+
+  local configs_to_run = vim.tbl_map(function(config)
+    return { config = config, name = config.exe }
+  end, configs)
+
+  M.start_task(configs_to_run, start_line - 1, end_line)
+end
+
 function M.start_task(configs, start_line, end_line, opts)
   opts = vim.tbl_deep_extend("keep", opts or {}, {
     lock = false,

--- a/plugin/formatter.vim
+++ b/plugin/formatter.vim
@@ -7,6 +7,11 @@ command! -nargs=? -range=% -bar
 \   Format lua require("formatter.format").format(
 \     <q-args>, <q-mods>, <line1>, <line2>)
 
+command! -nargs=1 -range=% -bar
+\   -complete=filetype
+\   FormatAs lua require("formatter.format").format_as(
+\     <q-args>, <q-mods>, <line1>, <line2>)
+
 command! -nargs=? -range=% -bar
 \   -complete=customlist,s:formatter_complete
 \   FormatWrite lua require("formatter.format").format(


### PR DESCRIPTION
I found myself wanting to format code of one language that was embedded inside another, for e.g. SQL inside of JavaScript, or Lua inside of Markdown, etc. I made `FormatAs` which allows you to visually select the code you want to format taking the code's filetype as the first argument, and formats it.

> ```vim
> [range]FormatAs {filetype}
> ```
> 
> Formats the range (defaulting to the whole file) as `{filetype}`, useful if you
> want to format code of `{filetype}` when embedded in a file of another
> filetype, for e.g. format a javascript snippet when inside markdown, or SQL
> inside of javascript, etc.

It works pretty well, although I would have liked to read the indent of the code in question and reestablish it after formatting, is that something that's easy/desired?