### PR TITLE
Add nim lang with formatters nimpretty and nph

### DIFF
--- a/lua/formatter/filetypes/nim.lua
+++ b/lua/formatter/filetypes/nim.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+function M.nph()
+  return {
+    exe = "nph",
+    args = {},
+    stdin = false,
+  }
+end
+
+return M

--- a/lua/formatter/filetypes/nim.lua
+++ b/lua/formatter/filetypes/nim.lua
@@ -1,5 +1,13 @@
 local M = {}
 
+function M.nimpretty()
+  return {
+    exe = "nimpretty",
+    args = {},
+    stdin = false,
+  }
+end
+
 function M.nph()
   return {
     exe = "nph",

--- a/lua/formatter/filetypes/nim.lua
+++ b/lua/formatter/filetypes/nim.lua
@@ -3,7 +3,6 @@ local M = {}
 function M.nimpretty()
   return {
     exe = "nimpretty",
-    args = {},
     stdin = false,
   }
 end
@@ -11,7 +10,6 @@ end
 function M.nph()
   return {
     exe = "nph",
-    args = {},
     stdin = false,
   }
 end


### PR DESCRIPTION
Added [nim lang](https://nim-lang.org/) with 2 formatters.

`nimpretty` comes with the nim compiler.
[nph](https://github.com/arnetheduck/nph) is an opinionated formatter.