### PR TITLE
Allow passing current file name/path as argument to formatter, fixes #324

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ return function(parser)
       exe = "prettier",
       args = {
         "--stdin-filepath",
-        util.escape_path(util.get_current_buffer_file_path()),
+        "$FILE_PATH",
       },
       stdin = true,
       try_node_modules = true,
@@ -35,7 +35,7 @@ return function(parser)
     exe = "prettier",
     args = {
       "--stdin-filepath",
-      util.escape_path(util.get_current_buffer_file_path()),
+      "$FILE_PATH",
       "--parser",
       parser,
     },

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ require("formatter").setup {
           args = {
             "--search-parent-directories",
             "--stdin-filepath",
-            util.escape_path(util.get_current_buffer_file_path()),
+            "$FILE_PATH",
             "--",
             "-",
           },

--- a/doc/formatter.txt
+++ b/doc/formatter.txt
@@ -92,6 +92,8 @@ Setup:
         -- You can also define your own configuration
         function()
           -- Supports conditional formatting
+          -- Note: util.get_current_buffer_file_name() will return the first file edited
+          -- so this will not work when using :edit etc. to open a new file
           if util.get_current_buffer_file_name() == "special.lua" then
             return nil
           end
@@ -103,7 +105,7 @@ Setup:
             args = {
               "--search-parent-directories",
               "--stdin-filepath",
-              util.escape_path(util.get_current_buffer_file_path()),
+              "$FILE_PATH",
               "--",
               "-",
             },
@@ -276,7 +278,7 @@ default configuration function takes in a parser argument:
         exe = "prettier",
         args = {
           "--stdin-filepath",
-          util.escape_path(util.get_current_buffer_file_path()),
+          "$FILE_PATH",
         },
         stdin = true,
         try_node_modules = true,
@@ -287,7 +289,7 @@ default configuration function takes in a parser argument:
       exe = "prettier",
       args = {
         "--stdin-filepath",
-        util.escape_path(util.get_current_buffer_file_path()),
+        "$FILE_PATH",
         "--parser",
         parser,
       },

--- a/lua/formatter/defaults/biome.lua
+++ b/lua/formatter/defaults/biome.lua
@@ -6,7 +6,7 @@ return function()
     args = {
         "format",
         "--stdin-file-path",
-        util.escape_path(util.get_current_buffer_file_path()),
+        "$FILE_PATH",
     },
     stdin = true,
   }

--- a/lua/formatter/defaults/clangformat.lua
+++ b/lua/formatter/defaults/clangformat.lua
@@ -5,7 +5,7 @@ return function()
     exe = "clang-format",
     args = {
       "-assume-filename",
-      util.escape_path(util.get_current_buffer_file_name()),
+      "$FILE_PATH",
     },
     stdin = true,
     try_node_modules = true,

--- a/lua/formatter/defaults/eslint_d.lua
+++ b/lua/formatter/defaults/eslint_d.lua
@@ -6,7 +6,7 @@ return function()
     args = {
       "--stdin",
       "--stdin-filename",
-      util.escape_path(util.get_current_buffer_file_path()),
+      "$FILE_PATH",
       "--fix-to-stdout",
     },
     stdin = true,

--- a/lua/formatter/defaults/ocamlformat.lua
+++ b/lua/formatter/defaults/ocamlformat.lua
@@ -4,7 +4,7 @@ return function()
     exe = "ocamlformat",
     args = {
       "--enable-outside-detected-project",
-      util.escape_path(util.get_current_buffer_file_name()),
+      "$FILE_PATH",
     },
     stdin = true,
   }

--- a/lua/formatter/defaults/prettier.lua
+++ b/lua/formatter/defaults/prettier.lua
@@ -6,7 +6,7 @@ return function(parser)
       exe = "prettier",
       args = {
         "--stdin-filepath",
-        util.escape_path(util.get_current_buffer_file_path()),
+        "$FILE_PATH",
       },
       stdin = true,
       try_node_modules = true,
@@ -17,7 +17,7 @@ return function(parser)
     exe = "prettier",
     args = {
       "--stdin-filepath",
-      util.escape_path(util.get_current_buffer_file_path()),
+      "$FILE_PATH",
       "--parser",
       parser,
     },

--- a/lua/formatter/defaults/prettierd.lua
+++ b/lua/formatter/defaults/prettierd.lua
@@ -3,7 +3,7 @@ local util = require "formatter.util"
 return function()
   return {
     exe = "prettierd",
-    args = { util.escape_path(util.get_current_buffer_file_path()) },
+    args = { "$FILE_PATH" },
     stdin = true,
   }
 end

--- a/lua/formatter/defaults/prettiereslint.lua
+++ b/lua/formatter/defaults/prettiereslint.lua
@@ -7,7 +7,7 @@ return function(parser)
       args = {
         "--stdin",
         "--stdin-filepath",
-        util.escape_path(util.get_current_buffer_file_path()),
+        "$FILE_PATH",
       },
       stdin = true,
       try_node_modules = true,
@@ -19,7 +19,7 @@ return function(parser)
     args = {
       "--stdin",
       "--stdin-filepath",
-      util.escape_path(util.get_current_buffer_file_path()),
+      "$FILE_PATH",
       "--parser",
       parser,
     },

--- a/lua/formatter/filetypes/eruby.lua
+++ b/lua/formatter/filetypes/eruby.lua
@@ -6,7 +6,7 @@ local M = {}
 function M.erbformatter()
   return {
     exe = "erb-formatter",
-    args = { util.escape_path(util.get_current_buffer_file_path()) },
+    args = { "$FILE_PATH" },
     stdin = true,
   }
 end

--- a/lua/formatter/filetypes/java.lua
+++ b/lua/formatter/filetypes/java.lua
@@ -15,7 +15,7 @@ function M.google_java_format()
         exe = "google-java-format",
         args = {
             "--aosp",
-            util.escape_path(util.get_current_buffer_file_path()),
+            "$FILE_PATH",
             "--replace"
         },
         stdin = true

--- a/lua/formatter/filetypes/json.lua
+++ b/lua/formatter/filetypes/json.lua
@@ -26,7 +26,7 @@ end
 function M.fixjson()
   return {
     exe = "fixjson",
-    args = { "--stdin-filename", util.get_current_buffer_file_name() },
+    args = { "--stdin-filename", "$FILE_NAME" },
     stdin = true,
     try_node_modules = true,
   }

--- a/lua/formatter/filetypes/lua.lua
+++ b/lua/formatter/filetypes/lua.lua
@@ -19,7 +19,7 @@ end
 function M.luaformat()
   return {
     exe = "lua-format",
-    args = {util.escape_path(util.get_current_buffer_file_path())},
+    args = {"$FILE_PATH"},
     stdin = true
   }
 end
@@ -30,7 +30,7 @@ function M.stylua()
     args = {
       "--search-parent-directories",
       "--stdin-filepath",
-      util.escape_path(util.get_current_buffer_file_path()),
+      "$FILE_PATH",
       "--",
       "-",
     },

--- a/lua/formatter/filetypes/python.lua
+++ b/lua/formatter/filetypes/python.lua
@@ -19,7 +19,7 @@ function M.isort()
   local util = require("formatter.util")
   return {
     exe = "isort",
-    args = { "-q", "--filename", util.escape_path(util.get_current_buffer_file_path()), "-" },
+    args = { "-q", "--filename", "$FILE_NAME", "-" },
     stdin = true,
   }
 end
@@ -36,7 +36,7 @@ function M.black()
   local util = require("formatter.util")
   return {
     exe = "black",
-    args = { "-q", "--stdin-filename", util.escape_path(util.get_current_buffer_file_name()), "-" },
+    args = { "-q", "--stdin-filename", "$FILE_NAME", "-" },
     stdin = true,
   }
 end

--- a/lua/formatter/filetypes/ruby.lua
+++ b/lua/formatter/filetypes/ruby.lua
@@ -8,7 +8,7 @@ function M.rubocop()
     args = {
       "--fix-layout",
       "--stdin",
-      util.escape_path(util.get_current_buffer_file_name()),
+      "$FILE_PATH",
       "--format",
       "files",
       "--stderr",
@@ -26,7 +26,7 @@ function M.standardrb()
       "quiet",
       "--stderr",
       "--stdin",
-      util.escape_path(util.get_current_buffer_file_path()),
+      "$FILE_PATH",
     },
     stdin = true,
   }

--- a/lua/formatter/filetypes/toml.lua
+++ b/lua/formatter/filetypes/toml.lua
@@ -4,7 +4,7 @@ function M.taplo()
   local util = require("formatter.util")
   return {
     exe = "taplo",
-    args = { "fmt", "--stdin-filepath", util.escape_path(util.get_current_buffer_file_path()),"-" },
+    args = { "fmt", "--stdin-filepath", "$FILE_PATH","-" },
     stdin = true,
     try_node_modules = true,
   }

--- a/lua/formatter/filetypes/xml.lua
+++ b/lua/formatter/filetypes/xml.lua
@@ -24,7 +24,7 @@ function M.xmllint()
     exe = "xmllint",
     args = {
       "--format",
-      util.escape_path(util.get_current_buffer_file_path()),
+      "$FILE_PATH",
     },
     stdin = true,
   }

--- a/lua/formatter/filetypes/zsh.lua
+++ b/lua/formatter/filetypes/zsh.lua
@@ -14,7 +14,7 @@ function M.beautysh()
     args = {
       "-i",
       shiftwidth,
-      util.escape_path(util.get_current_buffer_file_path()),
+      "$FILE_PATH",
     },
   }
 end

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -141,7 +141,13 @@ function M.start_task(configs, start_line, end_line, opts)
     local cmd = { current.config.exe }
     if current.config.args ~= nil then
       for _, arg in ipairs(current.config.args) do
-        table.insert(cmd, arg)
+        if arg == "$FILE_NAME" then
+          table.insert(cmd, util.escape_path(vim.fn.fnamemodify(bufname, ":t")))
+        elseif arg == "$FILE_PATH" then
+          table.insert(cmd, util.escape_path(bufname))
+        else
+          table.insert(cmd, arg)
+        end
       end
     end
 


### PR DESCRIPTION
See https://github.com/mhartington/formatter.nvim/issues/324, currently all configs pass the name of the buffer that was open when the config was first read (i.e. the first file passed on the command-line to `nvim`) because the formatter configs are only evaluated once.

This PR allows using `$FILE_PATH` and `$FILE_NAME` in the `args` of a formatter config, which will be replaced with the file name/path that is actually active in the editor when the formatting occurs.