### PR TITLE
add: mdformat for markdown formatting

### DIFF
--- a/lua/formatter/filetypes/markdown.lua
+++ b/lua/formatter/filetypes/markdown.lua
@@ -7,6 +7,14 @@ M.prettier = util.copyf(defaults.prettier)
 
 M.prettierd = util.copyf(defaults.prettierd)
 
+function M.mdformat()
+  return {
+    exe = "mdformat",
+    args = { "-" },
+    stdin = true,
+  }
+end
+
 function M.denofmt()
   local denofmt = util.copyf(defaults.denofmt)()
   table.insert(denofmt.args, "--ext")


### PR DESCRIPTION
Adds the [mdformat](https://github.com/executablebooks/mdformat) markdown formatter.

Tested locally and works just fine. `mdformat` only supports markdown, so I didn't add a `default` entry.