### PR TITLE
add Haskell formatters ormolu and fourmolu

### DIFF
--- a/lua/formatter/defaults/fourmolu.lua
+++ b/lua/formatter/defaults/fourmolu.lua
@@ -1,0 +1,12 @@
+local util = require "formatter.util"
+
+return function()
+  return {
+    exe = "fourmolu",
+    args = {
+      "--stdin-input-file",
+      util.escape_path(util.get_current_buffer_file_name()),
+    },
+    stdin = true,
+  }
+end

--- a/lua/formatter/defaults/ormolu.lua
+++ b/lua/formatter/defaults/ormolu.lua
@@ -1,0 +1,12 @@
+local util = require "formatter.util"
+
+return function()
+  return {
+    exe = "ormolu",
+    args = {
+      "--stdin-input-file",
+      util.escape_path(util.get_current_buffer_file_name()),
+    },
+    stdin = true,
+  }
+end

--- a/lua/formatter/defaults/stylish_haskell.lua
+++ b/lua/formatter/defaults/stylish_haskell.lua
@@ -1,0 +1,8 @@
+local util = require "formatter.util"
+
+return function()
+  return {
+    exe = "stylish-haskell",
+    stdin = true,
+  }
+end

--- a/lua/formatter/filetypes/haskell.lua
+++ b/lua/formatter/filetypes/haskell.lua
@@ -1,10 +1,10 @@
 local M = {}
 
-function M.stylish_haskell()
-  return {
-    exe = "stylish-haskell",
-    stdin = true,
-  }
-end
+local defaults = require "formatter.defaults"
+local util = require "formatter.util"
+
+M.stylish_haskell = util.copyf(defaults.stylish_haskell)
+M.ormolu = util.copyf(defaults.ormolu)
+M.fourmolu = util.copyf(defaults.fourmolu)
 
 return M


### PR DESCRIPTION
Adding support for other Haskell formatters:

- `ormolu`: https://github.com/tweag/ormolu
- `fourmolu`: https://github.com/fourmolu/fourmolu

Also moved the defaults of `stylish-haskell` to its own defaults file.