### PR TITLE
feat(python): add a formatter using ruff to sort imports

### DIFF
--- a/lua/formatter/filetypes/python.lua
+++ b/lua/formatter/filetypes/python.lua
@@ -49,6 +49,21 @@ function M.ruff()
   }
 end
 
+function M.iruff()
+  return {
+    exe = "ruff",
+    args = {
+      "check",
+      "-q",
+      "--select",
+      "I",
+      "--fix",
+      "-",
+    },
+    stdin = true,
+  }
+end
+
 function M.pyment()
   return {
     exe = "pyment",


### PR DESCRIPTION
Add a second formatter based on ruff for Python which formats only 
imports. This is different from the current ruff formatter which 
formats everything except imports. Therefore, users will have the
flexibility to format either everything, only imports, or everything
except imports based on the (ruff) formatter(s) they select.