### PR TITLE
feat:add params to goimports-reviser

### DIFF
--- a/lua/formatter/filetypes/go.lua
+++ b/lua/formatter/filetypes/go.lua
@@ -35,9 +35,14 @@ function M.golines()
   }
 end
 
-function M.goimports_reviser()
+-- @param params:table
+function M.goimports_reviser(params)
+  if params == nil or type(params) ~= "table" then
+    params = {}
+  end
   return {
     exe = "goimports-reviser",
+    args = params,
     stdin = false,
   }
 end


### PR DESCRIPTION
The goimports-reviser has some parameters that control the formatting behavior, and everyone may have different needs.