### PR TITLE
Utility to disable formatting based on git remote url

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ require("formatter").setup {
         if util.get_current_buffer_file_name() == "special.lua" then
           return nil
         end
+        -- Skip formatting for certain repositories. Looks for the "origin" remote by default.
+        -- Remote name can be passed as a parameter.
+        if string.find(util.get_current_buffer_git_remote_url(), "do-not-touch") then
+          return nil
+        end
 
         -- Full specification of configurations is down below and in Vim help
         -- files

--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -24,6 +24,21 @@ function M.get_current_buffer_file_extension()
   return vim.fn.fnamemodify(M.get_current_buffer_file_path(), ":e")
 end
 
+function M.get_current_buffer_git_remote_url(remote_name)
+    remote_name = remote_name or "origin"
+    local remote_url = vim.fn.system(
+        string.format(
+            "git -C %s config --get remote.%s.url",
+            M.escape_path(M.get_current_buffer_file_dir()),
+            remote_name
+        )
+    )
+    if remote_url == vim.NIL or remote_url == nil or vim.v.shell_error ~= 0 then
+        return ""
+    end
+    return vim.fn.trim(remote_url)
+end
+
 function M.quote_cmd_arg(arg)
   return string.format("'%s'", arg)
 end


### PR DESCRIPTION
The `get_current_buffer_git_remote_url` util fetches the remote url for the current buffer by using `git -C path/to/current/buffer config --get remote.origin.url`. If no remote is found or the current buffer is not part of a git repository, it returns an empty string.

This allows formatting to be disabled for specific repositories:

```lua
lua = {
    function()
        local util = require("formatter.util")
        if string.find(util.get_current_buffer_git_remote_url(), "nope") then
            return {}
        end
        return require("formatter.filetypes.lua").stylua()
    end,
},
```

By default, the util checks for a remote named `origin`. Other remote names can be specified as a parameter:

```lua
if string.find(util.get_current_buffer_git_remote_url("upstream"), "nope") then
    return {}
end
```