### PR TITLE
Revert exit code check for success

### DIFF
--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -116,7 +116,7 @@ function M.start_task(configs, start_line, end_line, opts)
       end
 
       -- Success
-      if ignore_exitcode or data then
+      if ignore_exitcode or data == 0 then
         if current_output == nil then
           current_output = { "" }
         end


### PR DESCRIPTION
This changes the success exit code back to check for 0 instead of just non-nil, because any non-zero error code is by definition non-nil.

Otherwise I end up seeing my buffer turn into this when I try to format a file with invalid syntax:

![CleanShot 2024-10-21 at 14 42 22@2x](https://github.com/user-attachments/assets/a720b9a0-fe03-4c2f-916c-7470c4f52fc9)
