### PR TITLE
fix "Failed to run formatter goimports-reviser"

### DIFF
--- a/lua/formatter/filetypes/go.lua
+++ b/lua/formatter/filetypes/go.lua
@@ -43,7 +43,7 @@ function M.goimports_reviser(params)
   return {
     exe = "goimports-reviser",
     args = params,
-    stdin = false,
+    stdin = true,
   }
 end
 


### PR DESCRIPTION
goimports-reviser must set stdin to true value, and put the current buffer file path in params, otherwise, an error will occur like "Failed to run formatter goimports-reviser. -: invalid input file name "~formatter_583456_a.go"2024/11/05 22:35:51 Failed to fix file: package has an errors".

The correct usage as follow:
require("formatter.filetypes.go").goimports_reviser({
            params1,
            params2,
            ...,
            util.escape_path(util.get_current_buffer_file_path()),
          }),