### PR TITLE
feat: add tex-fmt formatter.

### DIFF
--- a/lua/formatter/defaults/tex_fmt.lua
+++ b/lua/formatter/defaults/tex_fmt.lua
@@ -1,0 +1,10 @@
+return function()
+  return {
+    exe = "tex-fmt",
+    args = {
+      "--stdin",
+      "--print",
+    },
+    stdin = true,
+  }
+end

--- a/lua/formatter/filetypes/latex.lua
+++ b/lua/formatter/filetypes/latex.lua
@@ -4,5 +4,6 @@ local util = require "formatter.util"
 local defaults = require "formatter.defaults"
 
 M.latexindent = util.copyf(defaults.latexindent)
+M.tex_fmt = util.copyf(defaults.tex_fmt)
 
 return M

--- a/lua/formatter/filetypes/tex.lua
+++ b/lua/formatter/filetypes/tex.lua
@@ -1,10 +1,14 @@
 local M = {}
 
+local util = require "formatter.util"
+local defaults = require "formatter.defaults"
+
 function M.latexindent()
   return {
     exe = "latexindent -",
     stdin = true,
   }
 end
+M.tex_fmt = util.copyf(defaults.tex_fmt)
 
 return M


### PR DESCRIPTION
Adds support for the relatively new (but I would argue promising) tex/latex formatter "tex-fmt":

https://github.com/WGUNDERWOOD/tex-fmt

> An extremely fast LaTeX formatter written in Rust.

This is a super basic implementation and I am not a `formatter.nvim` expert - please let me know if you want stuff changed or if this is not how you want it implemented. Happy to tune :)


Also, while digging around the latex/tex formatter stuff, I noticed that `tex.lua` manually defines how to invoke `latexindent`, while `latex.lua` relies on the default in `latexindent.lua` which manually disables log file generation.
I presume this is an oversight? If so I am happy to clean this up.


Cheers!

